### PR TITLE
Added new features: Visual & timing fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ npm-debug.log
 # ShairportGUI specific files
 replace.sh
 image.png
+
+.vscode

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,40 +1,30 @@
 {
     "name": "shairportgui",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "shairportgui",
-            "version": "1.0.0",
+            "version": "1.0.1",
             "license": "ISC",
             "dependencies": {
                 "@check-light-or-dark/image": "^1.0.4",
-                "axios": "^0.27.2",
+                "axios": "^1.13.6",
                 "dotenv": "^16.0.1",
-                "express": "^4.18.1",
+                "express": "^5.2.1",
                 "marvinj": "^1.0.0",
-                "node-vibrant": "^3.2.1-alpha.1",
+                "node-vibrant": "^4.0.4",
                 "shairport-sync-reader": "^0.0.9",
-                "socket.io": "^4.5.0",
+                "socket.io": "^4.8.3",
                 "spotify-web-api-node": "^5.0.2"
             },
             "devDependencies": {
                 "@types/spotify-web-api-node": "^5.0.7",
                 "prettier": "2.6.2",
-                "ts-node": "^10.8.1",
+                "ts-node": "^10.9.2",
+                "tsx": "^4.21.0",
                 "typescript": "^4.7.3"
-            }
-        },
-        "node_modules/@babel/runtime": {
-            "version": "7.18.3",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.3.tgz",
-            "integrity": "sha512-38Y8f7YUhce/K7RMwTp7m0uCumpv9hZkitCbBClqQIow1qSbCvGkcegKOXpEWCQLfWmevgRiWokZ1GkpfhbZug==",
-            "dependencies": {
-                "regenerator-runtime": "^0.13.4"
-            },
-            "engines": {
-                "node": ">=6.9.0"
             }
         },
         "node_modules/@check-light-or-dark/image": {
@@ -62,13 +52,455 @@
                 "node": ">=12"
             }
         },
+        "node_modules/@esbuild/aix-ppc64": {
+            "version": "0.27.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+            "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "aix"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/android-arm": {
+            "version": "0.27.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+            "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/android-arm64": {
+            "version": "0.27.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+            "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/android-x64": {
+            "version": "0.27.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+            "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/darwin-arm64": {
+            "version": "0.27.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+            "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/darwin-x64": {
+            "version": "0.27.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+            "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/freebsd-arm64": {
+            "version": "0.27.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+            "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/freebsd-x64": {
+            "version": "0.27.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+            "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-arm": {
+            "version": "0.27.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+            "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-arm64": {
+            "version": "0.27.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+            "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-ia32": {
+            "version": "0.27.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+            "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-loong64": {
+            "version": "0.27.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+            "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-mips64el": {
+            "version": "0.27.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+            "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+            "cpu": [
+                "mips64el"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-ppc64": {
+            "version": "0.27.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+            "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-riscv64": {
+            "version": "0.27.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+            "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-s390x": {
+            "version": "0.27.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+            "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-x64": {
+            "version": "0.27.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+            "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/netbsd-arm64": {
+            "version": "0.27.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+            "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/netbsd-x64": {
+            "version": "0.27.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+            "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/openbsd-arm64": {
+            "version": "0.27.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+            "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/openbsd-x64": {
+            "version": "0.27.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+            "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/openharmony-arm64": {
+            "version": "0.27.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+            "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/sunos-x64": {
+            "version": "0.27.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+            "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "sunos"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/win32-arm64": {
+            "version": "0.27.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+            "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/win32-ia32": {
+            "version": "0.27.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+            "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/win32-x64": {
+            "version": "0.27.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+            "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/@jimp/bmp": {
-            "version": "0.16.1",
-            "resolved": "https://registry.npmjs.org/@jimp/bmp/-/bmp-0.16.1.tgz",
-            "integrity": "sha512-iwyNYQeBawrdg/f24x3pQ5rEx+/GwjZcCXd3Kgc+ZUd+Ivia7sIqBsOnDaMZdKCBPlfW364ekexnlOqyVa0NWg==",
+            "version": "0.22.12",
+            "resolved": "https://registry.npmjs.org/@jimp/bmp/-/bmp-0.22.12.tgz",
+            "integrity": "sha512-aeI64HD0npropd+AR76MCcvvRaa+Qck6loCOS03CkkxGHN5/r336qTM5HPUdHKMDOGzqknuVPA8+kK1t03z12g==",
+            "license": "MIT",
             "dependencies": {
-                "@babel/runtime": "^7.7.2",
-                "@jimp/utils": "^0.16.1",
+                "@jimp/utils": "^0.22.12",
                 "bmp-js": "^0.1.0"
             },
             "peerDependencies": {
@@ -76,40 +508,38 @@
             }
         },
         "node_modules/@jimp/core": {
-            "version": "0.16.1",
-            "resolved": "https://registry.npmjs.org/@jimp/core/-/core-0.16.1.tgz",
-            "integrity": "sha512-la7kQia31V6kQ4q1kI/uLimu8FXx7imWVajDGtwUG8fzePLWDFJyZl0fdIXVCL1JW2nBcRHidUot6jvlRDi2+g==",
+            "version": "0.22.12",
+            "resolved": "https://registry.npmjs.org/@jimp/core/-/core-0.22.12.tgz",
+            "integrity": "sha512-l0RR0dOPyzMKfjUW1uebzueFEDtCOj9fN6pyTYWWOM/VS4BciXQ1VVrJs8pO3kycGYZxncRKhCoygbNr8eEZQA==",
+            "license": "MIT",
             "dependencies": {
-                "@babel/runtime": "^7.7.2",
-                "@jimp/utils": "^0.16.1",
+                "@jimp/utils": "^0.22.12",
                 "any-base": "^1.1.0",
                 "buffer": "^5.2.0",
                 "exif-parser": "^0.1.12",
-                "file-type": "^9.0.0",
-                "load-bmfont": "^1.3.1",
-                "mkdirp": "^0.5.1",
-                "phin": "^2.9.1",
+                "file-type": "^16.5.4",
+                "isomorphic-fetch": "^3.0.0",
                 "pixelmatch": "^4.0.2",
-                "tinycolor2": "^1.4.1"
+                "tinycolor2": "^1.6.0"
             }
         },
         "node_modules/@jimp/custom": {
-            "version": "0.16.1",
-            "resolved": "https://registry.npmjs.org/@jimp/custom/-/custom-0.16.1.tgz",
-            "integrity": "sha512-DNUAHNSiUI/j9hmbatD6WN/EBIyeq4AO0frl5ETtt51VN1SvE4t4v83ZA/V6ikxEf3hxLju4tQ5Pc3zmZkN/3A==",
+            "version": "0.22.12",
+            "resolved": "https://registry.npmjs.org/@jimp/custom/-/custom-0.22.12.tgz",
+            "integrity": "sha512-xcmww1O/JFP2MrlGUMd3Q78S3Qu6W3mYTXYuIqFq33EorgYHV/HqymHfXy9GjiCJ7OI+7lWx6nYFOzU7M4rd1Q==",
+            "license": "MIT",
             "dependencies": {
-                "@babel/runtime": "^7.7.2",
-                "@jimp/core": "^0.16.1"
+                "@jimp/core": "^0.22.12"
             }
         },
         "node_modules/@jimp/gif": {
-            "version": "0.16.1",
-            "resolved": "https://registry.npmjs.org/@jimp/gif/-/gif-0.16.1.tgz",
-            "integrity": "sha512-r/1+GzIW1D5zrP4tNrfW+3y4vqD935WBXSc8X/wm23QTY9aJO9Lw6PEdzpYCEY+SOklIFKaJYUAq/Nvgm/9ryw==",
+            "version": "0.22.12",
+            "resolved": "https://registry.npmjs.org/@jimp/gif/-/gif-0.22.12.tgz",
+            "integrity": "sha512-y6BFTJgch9mbor2H234VSjd9iwAhaNf/t3US5qpYIs0TSbAvM02Fbc28IaDETj9+4YB4676sz4RcN/zwhfu1pg==",
+            "license": "MIT",
             "dependencies": {
-                "@babel/runtime": "^7.7.2",
-                "@jimp/utils": "^0.16.1",
-                "gifwrap": "^0.9.2",
+                "@jimp/utils": "^0.22.12",
+                "gifwrap": "^0.10.1",
                 "omggif": "^1.0.9"
             },
             "peerDependencies": {
@@ -117,66 +547,66 @@
             }
         },
         "node_modules/@jimp/jpeg": {
-            "version": "0.16.1",
-            "resolved": "https://registry.npmjs.org/@jimp/jpeg/-/jpeg-0.16.1.tgz",
-            "integrity": "sha512-8352zrdlCCLFdZ/J+JjBslDvml+fS3Z8gttdml0We759PnnZGqrnPRhkOEOJbNUlE+dD4ckLeIe6NPxlS/7U+w==",
+            "version": "0.22.12",
+            "resolved": "https://registry.npmjs.org/@jimp/jpeg/-/jpeg-0.22.12.tgz",
+            "integrity": "sha512-Rq26XC/uQWaQKyb/5lksCTCxXhtY01NJeBN+dQv5yNYedN0i7iYu+fXEoRsfaJ8xZzjoANH8sns7rVP4GE7d/Q==",
+            "license": "MIT",
             "dependencies": {
-                "@babel/runtime": "^7.7.2",
-                "@jimp/utils": "^0.16.1",
-                "jpeg-js": "0.4.2"
+                "@jimp/utils": "^0.22.12",
+                "jpeg-js": "^0.4.4"
             },
             "peerDependencies": {
                 "@jimp/custom": ">=0.3.5"
             }
         },
         "node_modules/@jimp/plugin-resize": {
-            "version": "0.16.1",
-            "resolved": "https://registry.npmjs.org/@jimp/plugin-resize/-/plugin-resize-0.16.1.tgz",
-            "integrity": "sha512-u4JBLdRI7dargC04p2Ha24kofQBk3vhaf0q8FwSYgnCRwxfvh2RxvhJZk9H7Q91JZp6wgjz/SjvEAYjGCEgAwQ==",
+            "version": "0.22.12",
+            "resolved": "https://registry.npmjs.org/@jimp/plugin-resize/-/plugin-resize-0.22.12.tgz",
+            "integrity": "sha512-3NyTPlPbTnGKDIbaBgQ3HbE6wXbAlFfxHVERmrbqAi8R3r6fQPxpCauA8UVDnieg5eo04D0T8nnnNIX//i/sXg==",
+            "license": "MIT",
             "dependencies": {
-                "@babel/runtime": "^7.7.2",
-                "@jimp/utils": "^0.16.1"
+                "@jimp/utils": "^0.22.12"
             },
             "peerDependencies": {
                 "@jimp/custom": ">=0.3.5"
             }
         },
         "node_modules/@jimp/png": {
-            "version": "0.16.1",
-            "resolved": "https://registry.npmjs.org/@jimp/png/-/png-0.16.1.tgz",
-            "integrity": "sha512-iyWoCxEBTW0OUWWn6SveD4LePW89kO7ZOy5sCfYeDM/oTPLpR8iMIGvZpZUz1b8kvzFr27vPst4E5rJhGjwsdw==",
+            "version": "0.22.12",
+            "resolved": "https://registry.npmjs.org/@jimp/png/-/png-0.22.12.tgz",
+            "integrity": "sha512-Mrp6dr3UTn+aLK8ty/dSKELz+Otdz1v4aAXzV5q53UDD2rbB5joKVJ/ChY310B+eRzNxIovbUF1KVrUsYdE8Hg==",
+            "license": "MIT",
             "dependencies": {
-                "@babel/runtime": "^7.7.2",
-                "@jimp/utils": "^0.16.1",
-                "pngjs": "^3.3.3"
+                "@jimp/utils": "^0.22.12",
+                "pngjs": "^6.0.0"
             },
             "peerDependencies": {
                 "@jimp/custom": ">=0.3.5"
             }
         },
         "node_modules/@jimp/tiff": {
-            "version": "0.16.1",
-            "resolved": "https://registry.npmjs.org/@jimp/tiff/-/tiff-0.16.1.tgz",
-            "integrity": "sha512-3K3+xpJS79RmSkAvFMgqY5dhSB+/sxhwTFA9f4AVHUK0oKW+u6r52Z1L0tMXHnpbAdR9EJ+xaAl2D4x19XShkQ==",
+            "version": "0.22.12",
+            "resolved": "https://registry.npmjs.org/@jimp/tiff/-/tiff-0.22.12.tgz",
+            "integrity": "sha512-E1LtMh4RyJsoCAfAkBRVSYyZDTtLq9p9LUiiYP0vPtXyxX4BiYBUYihTLSBlCQg5nF2e4OpQg7SPrLdJ66u7jg==",
+            "license": "MIT",
             "dependencies": {
-                "@babel/runtime": "^7.7.2",
-                "utif": "^2.0.1"
+                "utif2": "^4.0.1"
             },
             "peerDependencies": {
                 "@jimp/custom": ">=0.3.5"
             }
         },
         "node_modules/@jimp/types": {
-            "version": "0.16.1",
-            "resolved": "https://registry.npmjs.org/@jimp/types/-/types-0.16.1.tgz",
-            "integrity": "sha512-g1w/+NfWqiVW4CaXSJyD28JQqZtm2eyKMWPhBBDCJN9nLCN12/Az0WFF3JUAktzdsEC2KRN2AqB1a2oMZBNgSQ==",
+            "version": "0.22.12",
+            "resolved": "https://registry.npmjs.org/@jimp/types/-/types-0.22.12.tgz",
+            "integrity": "sha512-wwKYzRdElE1MBXFREvCto5s699izFHNVvALUv79GXNbsOVqlwlOxlWJ8DuyOGIXoLP4JW/m30YyuTtfUJgMRMA==",
+            "license": "MIT",
             "dependencies": {
-                "@babel/runtime": "^7.7.2",
-                "@jimp/bmp": "^0.16.1",
-                "@jimp/gif": "^0.16.1",
-                "@jimp/jpeg": "^0.16.1",
-                "@jimp/png": "^0.16.1",
-                "@jimp/tiff": "^0.16.1",
+                "@jimp/bmp": "^0.22.12",
+                "@jimp/gif": "^0.22.12",
+                "@jimp/jpeg": "^0.22.12",
+                "@jimp/png": "^0.22.12",
+                "@jimp/tiff": "^0.22.12",
                 "timm": "^1.6.1"
             },
             "peerDependencies": {
@@ -184,11 +614,11 @@
             }
         },
         "node_modules/@jimp/utils": {
-            "version": "0.16.1",
-            "resolved": "https://registry.npmjs.org/@jimp/utils/-/utils-0.16.1.tgz",
-            "integrity": "sha512-8fULQjB0x4LzUSiSYG6ZtQl355sZjxbv8r9PPAuYHzS9sGiSHJQavNqK/nKnpDsVkU88/vRGcE7t3nMU0dEnVw==",
+            "version": "0.22.12",
+            "resolved": "https://registry.npmjs.org/@jimp/utils/-/utils-0.22.12.tgz",
+            "integrity": "sha512-yJ5cWUknGnilBq97ZXOyOS0HhsHOyAyjHwYfHxGbSyMTohgQI6sVyE8KPgDwH8HHW/nMKXk8TrSwAE71zt716Q==",
+            "license": "MIT",
             "dependencies": {
-                "@babel/runtime": "^7.7.2",
                 "regenerator-runtime": "^0.13.3"
             }
         },
@@ -217,6 +647,18 @@
                 "@jridgewell/sourcemap-codec": "^1.4.10"
             }
         },
+        "node_modules/@socket.io/component-emitter": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
+            "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
+            "license": "MIT"
+        },
+        "node_modules/@tokenizer/token": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+            "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
+            "license": "MIT"
+        },
         "node_modules/@tsconfig/node10": {
             "version": "1.0.9",
             "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
@@ -241,25 +683,23 @@
             "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
             "dev": true
         },
-        "node_modules/@types/component-emitter": {
-            "version": "1.2.11",
-            "resolved": "https://registry.npmjs.org/@types/component-emitter/-/component-emitter-1.2.11.tgz",
-            "integrity": "sha512-SRXjM+tfsSlA9VuG8hGO2nft2p8zjXCK1VcC6N4NXbBbYbSia9kzCChYQajIjzIqOOOuh5Ock6MmV2oux4jDZQ=="
-        },
-        "node_modules/@types/cookie": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
-            "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q=="
-        },
         "node_modules/@types/cors": {
-            "version": "2.8.12",
-            "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.12.tgz",
-            "integrity": "sha512-vt+kDhq/M2ayberEtJcIN/hxXy1Pk+59g2FV/ZQceeaTyCtCucjL2Q7FXlFjtWn4n15KCr1NE2lNNFhp0lEThw=="
+            "version": "2.8.19",
+            "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+            "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*"
+            }
         },
         "node_modules/@types/node": {
-            "version": "17.0.33",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.33.tgz",
-            "integrity": "sha512-miWq2m2FiQZmaHfdZNcbpp9PuXg34W5JZ5CrJ/BaS70VuhoJENBEQybeiYSaPBRNq6KQGnjfEnc/F3PN++D+XQ=="
+            "version": "18.19.130",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+            "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+            "license": "MIT",
+            "dependencies": {
+                "undici-types": "~5.26.4"
+            }
         },
         "node_modules/@types/spotify-api": {
             "version": "0.0.16",
@@ -277,112 +717,203 @@
             }
         },
         "node_modules/@vibrant/color": {
-            "version": "3.2.1-alpha.1",
-            "resolved": "https://registry.npmjs.org/@vibrant/color/-/color-3.2.1-alpha.1.tgz",
-            "integrity": "sha512-cvm+jAPwao2NerTr3d1JttYyLhp3eD/AQBeevxF7KT6HctToWZCwr2AeTr003/wKgbjzdOV1qySnbyOeu+R+Jw=="
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/@vibrant/color/-/color-4.0.4.tgz",
+            "integrity": "sha512-Fq2tAszz4QOPWfHZ+KuEAchXUD8i594BM2fOJt8dI/fvYbiVoBycBF/BlNH6F4IWBubxXoPqD4JmmAHvFYbNew==",
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/crutchcorn"
+            }
         },
         "node_modules/@vibrant/core": {
-            "version": "3.2.1-alpha.1",
-            "resolved": "https://registry.npmjs.org/@vibrant/core/-/core-3.2.1-alpha.1.tgz",
-            "integrity": "sha512-X9Oa9WfPEQnZ6L+5dLRlh+IlsxJkYTw9b/g3stFKoNXbVRKCeXHmH48l7jIBBOg3VcXOGUdsYBqsTwPNkIveaA==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/@vibrant/core/-/core-4.0.4.tgz",
+            "integrity": "sha512-yZ0XSpW2biKyaJPpBC31AVYgn7NseKSO2q3KNMmDrkL2qC6TEWsBMnSQ28n0m///chZELXpQLx1CCOsWg5pj8w==",
+            "license": "MIT",
             "dependencies": {
-                "@vibrant/color": "^3.2.1-alpha.1",
-                "@vibrant/generator": "^3.2.1-alpha.1",
-                "@vibrant/image": "^3.2.1-alpha.1",
-                "@vibrant/quantizer": "^3.2.1-alpha.1",
-                "@vibrant/types": "^3.2.1-alpha.1",
-                "@vibrant/worker": "^3.2.1-alpha.1"
+                "@vibrant/color": "^4.0.4",
+                "@vibrant/generator": "^4.0.4",
+                "@vibrant/image": "^4.0.4",
+                "@vibrant/quantizer": "^4.0.4",
+                "@vibrant/worker": "^4.0.4"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/crutchcorn"
             }
         },
         "node_modules/@vibrant/generator": {
-            "version": "3.2.1-alpha.1",
-            "resolved": "https://registry.npmjs.org/@vibrant/generator/-/generator-3.2.1-alpha.1.tgz",
-            "integrity": "sha512-luS5YvMhwMqG01YTj1dJ+cmkuIw1VCByOR6zIaCOwQqI/mcOs88JBWcA1r2TywJTOPlVpjfnDvAlyaKBKh4dMA==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/@vibrant/generator/-/generator-4.0.4.tgz",
+            "integrity": "sha512-rwq8PnlpKdch4YqaA1FAwdm71gKE2cMrUsbu72TqRFGa8rpP1roaZlQCVXIIwElXVc3r9axZyAcqyTLaMjhrTg==",
+            "license": "MIT",
             "dependencies": {
-                "@vibrant/color": "^3.2.1-alpha.1",
-                "@vibrant/types": "^3.2.1-alpha.1"
+                "@vibrant/color": "^4.0.4",
+                "@vibrant/types": "^4.0.4"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/crutchcorn"
             }
         },
         "node_modules/@vibrant/generator-default": {
-            "version": "3.2.1-alpha.1",
-            "resolved": "https://registry.npmjs.org/@vibrant/generator-default/-/generator-default-3.2.1-alpha.1.tgz",
-            "integrity": "sha512-BWnQhDaz92UhyHnpdAzKXHQecY+jvyMXtzjKYbveFxThm6+HVoLjwONlbck7oyOpFzV2OM7V11XuR85BxaHvjw==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/@vibrant/generator-default/-/generator-default-4.0.4.tgz",
+            "integrity": "sha512-QeVDeH2dz9lityvJCb84Ml4hlBTElwCpU7SVpiDFBh6gPoCLnzcb1H9G4NgG3hOlAPyrBM+Ivq1Pg+1lZj5Ywg==",
+            "license": "MIT",
             "dependencies": {
-                "@vibrant/color": "^3.2.1-alpha.1",
-                "@vibrant/generator": "^3.2.1-alpha.1"
+                "@vibrant/color": "^4.0.4",
+                "@vibrant/generator": "^4.0.4"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/crutchcorn"
             }
         },
         "node_modules/@vibrant/image": {
-            "version": "3.2.1-alpha.1",
-            "resolved": "https://registry.npmjs.org/@vibrant/image/-/image-3.2.1-alpha.1.tgz",
-            "integrity": "sha512-4aF5k79QfyhZOqRovJpbnIjWfe3uuWhY8voqVdd4/qgu4o70/AwVlM+pYmCaJVzI45VWNWWHYA5QlYuKsXnBqQ==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/@vibrant/image/-/image-4.0.4.tgz",
+            "integrity": "sha512-NBIJj7umfDRVpFjJHQo1AFSCWCzQyjfil+Yxu7W62PEL72GPCif0CDiglPkvVF8QhDLmnx/x1k3LIBb9jWF2sw==",
+            "license": "MIT",
             "dependencies": {
-                "@vibrant/color": "^3.2.1-alpha.1",
-                "@vibrant/types": "^3.2.1-alpha.1"
+                "@vibrant/color": "^4.0.4"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/crutchcorn"
             }
         },
         "node_modules/@vibrant/image-browser": {
-            "version": "3.2.1-alpha.1",
-            "resolved": "https://registry.npmjs.org/@vibrant/image-browser/-/image-browser-3.2.1-alpha.1.tgz",
-            "integrity": "sha512-6xWvQfB20sE6YtCWylgEAHuee3iD8h3aFIDbCS2yj7jIelKcYTrrp5jg2d2BhOOB6pC5JzF+QfpCrm0DmAIlgQ==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/@vibrant/image-browser/-/image-browser-4.0.4.tgz",
+            "integrity": "sha512-7qVyAm+z9t98iwMDzUgGCwgRg0KBB5RXQFgiO2Um5Izd1wO7BKC0SHVEz2k7sRx3XNfBf+JExp8quPrvSz17gg==",
+            "license": "MIT",
             "dependencies": {
-                "@vibrant/image": "^3.2.1-alpha.1"
+                "@vibrant/image": "^4.0.4"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/crutchcorn"
             }
         },
         "node_modules/@vibrant/image-node": {
-            "version": "3.2.1-alpha.1",
-            "resolved": "https://registry.npmjs.org/@vibrant/image-node/-/image-node-3.2.1-alpha.1.tgz",
-            "integrity": "sha512-/Io/Rpo4EkO6AhaXdcxUXkbOFhSFtjm0LSAM4c0AyGA5EbC8PyZqjk8b11bQAEMCaYaweFQfTdGD7oVbXe21CQ==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/@vibrant/image-node/-/image-node-4.0.4.tgz",
+            "integrity": "sha512-aG8Ukt9oTa6FWaAV5oBKsBetkKASWH31hZiFJ2R1291f3TZlphUyQTJz5TubucIRsCEl4dgG1xyxFPgse2IABA==",
+            "license": "MIT",
             "dependencies": {
-                "@jimp/custom": "^0.16.1",
-                "@jimp/plugin-resize": "^0.16.1",
-                "@jimp/types": "^0.16.1",
-                "@vibrant/image": "^3.2.1-alpha.1"
+                "@jimp/custom": "^0.22.12",
+                "@jimp/plugin-resize": "^0.22.12",
+                "@jimp/types": "^0.22.12",
+                "@vibrant/image": "^4.0.4"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/crutchcorn"
             }
         },
         "node_modules/@vibrant/quantizer": {
-            "version": "3.2.1-alpha.1",
-            "resolved": "https://registry.npmjs.org/@vibrant/quantizer/-/quantizer-3.2.1-alpha.1.tgz",
-            "integrity": "sha512-iHnPx/+n4iLtYLm1GClSfyg2fFbMatFG0ipCyp9M6tXNIPAg+pSvUJSGBnVnH7Nl/bR8Gkkj1h0pJ4RsKcdIrQ==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/@vibrant/quantizer/-/quantizer-4.0.4.tgz",
+            "integrity": "sha512-722CooC2W4mlBiv+zyAsIrIvARnMCN/P2Muo8bnWd0SQlVWFtQnFxJWGOUPOPS4DGe3pGoqmNfvS0let4dICZQ==",
+            "license": "MIT",
             "dependencies": {
-                "@vibrant/color": "^3.2.1-alpha.1",
-                "@vibrant/image": "^3.2.1-alpha.1",
-                "@vibrant/types": "^3.2.1-alpha.1"
+                "@vibrant/color": "^4.0.4",
+                "@vibrant/image": "^4.0.4",
+                "@vibrant/types": "^4.0.4"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/crutchcorn"
             }
         },
         "node_modules/@vibrant/quantizer-mmcq": {
-            "version": "3.2.1-alpha.1",
-            "resolved": "https://registry.npmjs.org/@vibrant/quantizer-mmcq/-/quantizer-mmcq-3.2.1-alpha.1.tgz",
-            "integrity": "sha512-Wuk9PTZtxr8qsWTcgP6lcrrmrq36syVwxf+BUxdgQYntBcQ053SaN34lVGOJ0WPdK5vABoxbYljhceCgiILtZw==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/@vibrant/quantizer-mmcq/-/quantizer-mmcq-4.0.4.tgz",
+            "integrity": "sha512-/1CNnM96J8K+OBCWNUzywo6VdnmdFJyiKO+ty/nkfe8H0NseOEHIL7PrVtWGgtsb0rh2uTAq2rjXv65TfgPy8g==",
+            "license": "MIT",
             "dependencies": {
-                "@vibrant/color": "^3.2.1-alpha.1",
-                "@vibrant/image": "^3.2.1-alpha.1",
-                "@vibrant/quantizer": "^3.2.1-alpha.1"
+                "@vibrant/color": "^4.0.4",
+                "@vibrant/image": "^4.0.4",
+                "@vibrant/quantizer": "^4.0.4"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/crutchcorn"
             }
         },
         "node_modules/@vibrant/types": {
-            "version": "3.2.1-alpha.1",
-            "resolved": "https://registry.npmjs.org/@vibrant/types/-/types-3.2.1-alpha.1.tgz",
-            "integrity": "sha512-ts9u7nsrENoYI5s0MmPOeY5kCLFKvQndKVDOPFCbTA0z493uhDp8mpiQhjFYTf3kPbS04z9zbHLE2luFC7x4KQ=="
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/@vibrant/types/-/types-4.0.4.tgz",
+            "integrity": "sha512-Qq3mVTJamn7yD4OBgBEUKaxfDlm3sxBK55N7dH3XzI9Ey7KR00R06uwtqOcEJMsziWTEXdYN3VUlYaj2Tkt7hw==",
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/crutchcorn"
+            }
         },
         "node_modules/@vibrant/worker": {
-            "version": "3.2.1-alpha.1",
-            "resolved": "https://registry.npmjs.org/@vibrant/worker/-/worker-3.2.1-alpha.1.tgz",
-            "integrity": "sha512-mtSlBdHkFNr4FOnMtqtHJxy9z5AsUcZzGlpiHzvWOoaoN9lNTDPwxOBd0q4VTYWuGPrIm6Fuq5m7aRbLv7KqiQ==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/@vibrant/worker/-/worker-4.0.4.tgz",
+            "integrity": "sha512-Q/R6PYhSMWCXEk/IcXbWIzIu7Z4b58ABkGvcdF8Y+q/7g+KnpxKW5x/jfQ/6ciyYSby13wZZoEdNr3QQVgsdBQ==",
+            "license": "MIT",
             "dependencies": {
-                "@vibrant/types": "^3.2.1-alpha.1"
+                "@vibrant/types": "^4.0.4"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/crutchcorn"
+            }
+        },
+        "node_modules/abort-controller": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+            "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+            "license": "MIT",
+            "dependencies": {
+                "event-target-shim": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=6.5"
             }
         },
         "node_modules/accepts": {
-            "version": "1.3.8",
-            "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
-            "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+            "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+            "license": "MIT",
             "dependencies": {
-                "mime-types": "~2.1.34",
-                "negotiator": "0.6.3"
+                "mime-types": "^3.0.0",
+                "negotiator": "^1.0.0"
             },
             "engines": {
                 "node": ">= 0.6"
+            }
+        },
+        "node_modules/accepts/node_modules/mime-db": {
+            "version": "1.54.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+            "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/accepts/node_modules/mime-types": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+            "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+            "license": "MIT",
+            "dependencies": {
+                "mime-db": "^1.54.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/acorn": {
@@ -409,7 +940,8 @@
         "node_modules/any-base": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/any-base/-/any-base-1.1.0.tgz",
-            "integrity": "sha512-uMgjozySS8adZZYePpaWs8cxB9/kdzmpX6SgJZ+wbz1K5eYk5QMYDVJaZKhxyIHUdnnJkfR7SVgStgH7LkGUyg=="
+            "integrity": "sha512-uMgjozySS8adZZYePpaWs8cxB9/kdzmpX6SgJZ+wbz1K5eYk5QMYDVJaZKhxyIHUdnnJkfR7SVgStgH7LkGUyg==",
+            "license": "MIT"
         },
         "node_modules/arg": {
             "version": "4.1.3",
@@ -417,32 +949,32 @@
             "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
             "dev": true
         },
-        "node_modules/array-flatten": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-            "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
-        },
         "node_modules/asynckit": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
             "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
         },
         "node_modules/axios": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-            "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+            "version": "1.13.6",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
+            "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
+            "license": "MIT",
             "dependencies": {
-                "follow-redirects": "^1.14.9",
-                "form-data": "^4.0.0"
+                "follow-redirects": "^1.15.11",
+                "form-data": "^4.0.5",
+                "proxy-from-env": "^1.1.0"
             }
         },
         "node_modules/axios/node_modules/form-data": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-            "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+            "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+            "license": "MIT",
             "dependencies": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.8",
+                "es-set-tostringtag": "^2.1.0",
+                "hasown": "^2.0.2",
                 "mime-types": "^2.1.12"
             },
             "engines": {
@@ -466,12 +998,14 @@
                     "type": "consulting",
                     "url": "https://feross.org/support"
                 }
-            ]
+            ],
+            "license": "MIT"
         },
         "node_modules/base64id": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
             "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
+            "license": "MIT",
             "engines": {
                 "node": "^4.5.0 || >= 5.9"
             }
@@ -479,29 +1013,31 @@
         "node_modules/bmp-js": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/bmp-js/-/bmp-js-0.1.0.tgz",
-            "integrity": "sha512-vHdS19CnY3hwiNdkaqk93DvjVLfbEcI8mys4UjuWrlX1haDmroo8o4xCzh4wD6DGV6HxRCyauwhHRqMTfERtjw=="
+            "integrity": "sha512-vHdS19CnY3hwiNdkaqk93DvjVLfbEcI8mys4UjuWrlX1haDmroo8o4xCzh4wD6DGV6HxRCyauwhHRqMTfERtjw==",
+            "license": "MIT"
         },
         "node_modules/body-parser": {
-            "version": "1.20.0",
-            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.0.tgz",
-            "integrity": "sha512-DfJ+q6EPcGKZD1QWUjSpqp+Q7bDQTsQIF4zfUAtZ6qk+H/3/QRhg9CEp39ss+/T2vw0+HaidC0ecJj/DRLIaKg==",
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+            "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+            "license": "MIT",
             "dependencies": {
-                "bytes": "3.1.2",
-                "content-type": "~1.0.4",
-                "debug": "2.6.9",
-                "depd": "2.0.0",
-                "destroy": "1.2.0",
-                "http-errors": "2.0.0",
-                "iconv-lite": "0.4.24",
-                "on-finished": "2.4.1",
-                "qs": "6.10.3",
-                "raw-body": "2.5.1",
-                "type-is": "~1.6.18",
-                "unpipe": "1.0.0"
+                "bytes": "^3.1.2",
+                "content-type": "^1.0.5",
+                "debug": "^4.4.3",
+                "http-errors": "^2.0.0",
+                "iconv-lite": "^0.7.0",
+                "on-finished": "^2.4.1",
+                "qs": "^6.14.1",
+                "raw-body": "^3.0.1",
+                "type-is": "^2.0.1"
             },
             "engines": {
-                "node": ">= 0.8",
-                "npm": "1.2.8000 || >= 1.4.16"
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/buffer": {
@@ -522,34 +1058,45 @@
                     "url": "https://feross.org/support"
                 }
             ],
+            "license": "MIT",
             "dependencies": {
                 "base64-js": "^1.3.1",
                 "ieee754": "^1.1.13"
-            }
-        },
-        "node_modules/buffer-equal": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz",
-            "integrity": "sha512-RgSV6InVQ9ODPdLWJ5UAqBqJBOg370Nz6ZQtRzpt6nUjc8v0St97uJ4PYC6NztqIScrAXafKM3mZPMygSe1ggA==",
-            "engines": {
-                "node": ">=0.4.0"
             }
         },
         "node_modules/bytes": {
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
             "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
             }
         },
-        "node_modules/call-bind": {
+        "node_modules/call-bind-apply-helpers": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-            "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+            "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+            "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+            "license": "MIT",
             "dependencies": {
-                "function-bind": "^1.1.1",
-                "get-intrinsic": "^1.0.2"
+                "es-errors": "^1.3.0",
+                "function-bind": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/call-bound": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+            "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.2",
+                "get-intrinsic": "^1.3.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -572,36 +1119,44 @@
             "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
         },
         "node_modules/content-disposition": {
-            "version": "0.5.4",
-            "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
-            "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
-            "dependencies": {
-                "safe-buffer": "5.2.1"
-            },
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+            "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+            "license": "MIT",
             "engines": {
-                "node": ">= 0.6"
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/content-type": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-            "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+            "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
             }
         },
         "node_modules/cookie": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-            "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+            "version": "0.7.2",
+            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+            "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
             }
         },
         "node_modules/cookie-signature": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-            "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+            "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.6.0"
+            }
         },
         "node_modules/cookiejar": {
             "version": "2.1.3",
@@ -609,15 +1164,20 @@
             "integrity": "sha512-JxbCBUdrfr6AQjOXrxoTvAMJO4HBTUIlBzslcJPAz+/KT8yk53fXun51u+RenNYvad/+Vc2DIz5o9UxlCDymFQ=="
         },
         "node_modules/cors": {
-            "version": "2.8.5",
-            "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
-            "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+            "version": "2.8.6",
+            "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+            "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+            "license": "MIT",
             "dependencies": {
                 "object-assign": "^4",
                 "vary": "^1"
             },
             "engines": {
                 "node": ">= 0.10"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/create-require": {
@@ -635,11 +1195,20 @@
             }
         },
         "node_modules/debug": {
-            "version": "2.6.9",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+            "license": "MIT",
             "dependencies": {
-                "ms": "2.0.0"
+                "ms": "^2.1.3"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
             }
         },
         "node_modules/delayed-stream": {
@@ -654,17 +1223,9 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
             "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
-            }
-        },
-        "node_modules/destroy": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
-            "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
-            "engines": {
-                "node": ">= 0.8",
-                "npm": "1.2.8000 || >= 1.4.16"
             }
         },
         "node_modules/diff": {
@@ -676,11 +1237,6 @@
                 "node": ">=0.3.1"
             }
         },
-        "node_modules/dom-walk": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
-            "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="
-        },
         "node_modules/dotenv": {
             "version": "16.0.1",
             "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.1.tgz",
@@ -689,133 +1245,277 @@
                 "node": ">=12"
             }
         },
+        "node_modules/dunder-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+            "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "gopd": "^1.2.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
         "node_modules/ee-first": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-            "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+            "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+            "license": "MIT"
         },
         "node_modules/encodeurl": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-            "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+            "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
             }
         },
         "node_modules/engine.io": {
-            "version": "6.2.0",
-            "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.2.0.tgz",
-            "integrity": "sha512-4KzwW3F3bk+KlzSOY57fj/Jx6LyRQ1nbcyIadehl+AnXjKT7gDO0ORdRi/84ixvMKTym6ZKuxvbzN62HDDU1Lg==",
+            "version": "6.6.5",
+            "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.5.tgz",
+            "integrity": "sha512-2RZdgEbXmp5+dVbRm0P7HQUImZpICccJy7rN7Tv+SFa55pH+lxnuw6/K1ZxxBfHoYpSkHLAO92oa8O4SwFXA2A==",
+            "license": "MIT",
             "dependencies": {
-                "@types/cookie": "^0.4.1",
                 "@types/cors": "^2.8.12",
                 "@types/node": ">=10.0.0",
                 "accepts": "~1.3.4",
                 "base64id": "2.0.0",
-                "cookie": "~0.4.1",
+                "cookie": "~0.7.2",
                 "cors": "~2.8.5",
-                "debug": "~4.3.1",
-                "engine.io-parser": "~5.0.3",
-                "ws": "~8.2.3"
+                "debug": "~4.4.1",
+                "engine.io-parser": "~5.2.1",
+                "ws": "~8.18.3"
             },
             "engines": {
-                "node": ">=10.0.0"
+                "node": ">=10.2.0"
             }
         },
         "node_modules/engine.io-parser": {
-            "version": "5.0.4",
-            "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.0.4.tgz",
-            "integrity": "sha512-+nVFp+5z1E3HcToEnO7ZIj3g+3k9389DvWtvJZz0T6/eOCPIyyxehFcedoYrZQrp0LgQbD9pPXhpMBKMd5QURg==",
+            "version": "5.2.3",
+            "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
+            "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
+            "license": "MIT",
             "engines": {
                 "node": ">=10.0.0"
             }
         },
-        "node_modules/engine.io/node_modules/cookie": {
-            "version": "0.4.2",
-            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
-            "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
+        "node_modules/engine.io/node_modules/accepts": {
+            "version": "1.3.8",
+            "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+            "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+            "license": "MIT",
+            "dependencies": {
+                "mime-types": "~2.1.34",
+                "negotiator": "0.6.3"
+            },
             "engines": {
                 "node": ">= 0.6"
             }
         },
-        "node_modules/engine.io/node_modules/debug": {
-            "version": "4.3.4",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-            "dependencies": {
-                "ms": "2.1.2"
-            },
+        "node_modules/engine.io/node_modules/negotiator": {
+            "version": "0.6.3",
+            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+            "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+            "license": "MIT",
             "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
+                "node": ">= 0.6"
             }
         },
-        "node_modules/engine.io/node_modules/ms": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        "node_modules/es-define-property": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+            "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-errors": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+            "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-object-atoms": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+            "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-set-tostringtag": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+            "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.6",
+                "has-tostringtag": "^1.0.2",
+                "hasown": "^2.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/esbuild": {
+            "version": "0.27.3",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+            "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "bin": {
+                "esbuild": "bin/esbuild"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "optionalDependencies": {
+                "@esbuild/aix-ppc64": "0.27.3",
+                "@esbuild/android-arm": "0.27.3",
+                "@esbuild/android-arm64": "0.27.3",
+                "@esbuild/android-x64": "0.27.3",
+                "@esbuild/darwin-arm64": "0.27.3",
+                "@esbuild/darwin-x64": "0.27.3",
+                "@esbuild/freebsd-arm64": "0.27.3",
+                "@esbuild/freebsd-x64": "0.27.3",
+                "@esbuild/linux-arm": "0.27.3",
+                "@esbuild/linux-arm64": "0.27.3",
+                "@esbuild/linux-ia32": "0.27.3",
+                "@esbuild/linux-loong64": "0.27.3",
+                "@esbuild/linux-mips64el": "0.27.3",
+                "@esbuild/linux-ppc64": "0.27.3",
+                "@esbuild/linux-riscv64": "0.27.3",
+                "@esbuild/linux-s390x": "0.27.3",
+                "@esbuild/linux-x64": "0.27.3",
+                "@esbuild/netbsd-arm64": "0.27.3",
+                "@esbuild/netbsd-x64": "0.27.3",
+                "@esbuild/openbsd-arm64": "0.27.3",
+                "@esbuild/openbsd-x64": "0.27.3",
+                "@esbuild/openharmony-arm64": "0.27.3",
+                "@esbuild/sunos-x64": "0.27.3",
+                "@esbuild/win32-arm64": "0.27.3",
+                "@esbuild/win32-ia32": "0.27.3",
+                "@esbuild/win32-x64": "0.27.3"
+            }
         },
         "node_modules/escape-html": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-            "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+            "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+            "license": "MIT"
         },
         "node_modules/etag": {
             "version": "1.8.1",
             "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-            "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
+            "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
+            }
+        },
+        "node_modules/event-target-shim": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+            "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/events": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+            "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.8.x"
             }
         },
         "node_modules/exif-parser": {
             "version": "0.1.12",
             "resolved": "https://registry.npmjs.org/exif-parser/-/exif-parser-0.1.12.tgz",
-            "integrity": "sha1-WKnS1ywCwfbwKg70qRZicrd2CSI="
+            "integrity": "sha512-c2bQfLNbMzLPmzQuOr8fy0csy84WmwnER81W88DzTp9CYNPJ6yzOj2EZAh9pywYpqHnshVLHQJ8WzldAyfY+Iw=="
         },
         "node_modules/express": {
-            "version": "4.18.1",
-            "resolved": "https://registry.npmjs.org/express/-/express-4.18.1.tgz",
-            "integrity": "sha512-zZBcOX9TfehHQhtupq57OF8lFZ3UZi08Y97dwFCkD8p9d/d2Y3M+ykKcwaMDEL+4qyUolgBDX6AblpR3fL212Q==",
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+            "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+            "license": "MIT",
             "dependencies": {
-                "accepts": "~1.3.8",
-                "array-flatten": "1.1.1",
-                "body-parser": "1.20.0",
-                "content-disposition": "0.5.4",
-                "content-type": "~1.0.4",
-                "cookie": "0.5.0",
-                "cookie-signature": "1.0.6",
-                "debug": "2.6.9",
-                "depd": "2.0.0",
-                "encodeurl": "~1.0.2",
-                "escape-html": "~1.0.3",
-                "etag": "~1.8.1",
-                "finalhandler": "1.2.0",
-                "fresh": "0.5.2",
-                "http-errors": "2.0.0",
-                "merge-descriptors": "1.0.1",
-                "methods": "~1.1.2",
-                "on-finished": "2.4.1",
-                "parseurl": "~1.3.3",
-                "path-to-regexp": "0.1.7",
-                "proxy-addr": "~2.0.7",
-                "qs": "6.10.3",
-                "range-parser": "~1.2.1",
-                "safe-buffer": "5.2.1",
-                "send": "0.18.0",
-                "serve-static": "1.15.0",
-                "setprototypeof": "1.2.0",
-                "statuses": "2.0.1",
-                "type-is": "~1.6.18",
-                "utils-merge": "1.0.1",
-                "vary": "~1.1.2"
+                "accepts": "^2.0.0",
+                "body-parser": "^2.2.1",
+                "content-disposition": "^1.0.0",
+                "content-type": "^1.0.5",
+                "cookie": "^0.7.1",
+                "cookie-signature": "^1.2.1",
+                "debug": "^4.4.0",
+                "depd": "^2.0.0",
+                "encodeurl": "^2.0.0",
+                "escape-html": "^1.0.3",
+                "etag": "^1.8.1",
+                "finalhandler": "^2.1.0",
+                "fresh": "^2.0.0",
+                "http-errors": "^2.0.0",
+                "merge-descriptors": "^2.0.0",
+                "mime-types": "^3.0.0",
+                "on-finished": "^2.4.1",
+                "once": "^1.4.0",
+                "parseurl": "^1.3.3",
+                "proxy-addr": "^2.0.7",
+                "qs": "^6.14.0",
+                "range-parser": "^1.2.1",
+                "router": "^2.2.0",
+                "send": "^1.1.0",
+                "serve-static": "^2.2.0",
+                "statuses": "^2.0.1",
+                "type-is": "^2.0.1",
+                "vary": "^1.1.2"
             },
             "engines": {
-                "node": ">= 0.10.0"
+                "node": ">= 18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/express/node_modules/mime-db": {
+            "version": "1.54.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+            "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/express/node_modules/mime-types": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+            "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+            "license": "MIT",
+            "dependencies": {
+                "mime-db": "^1.54.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/fast-safe-stringify": {
@@ -824,40 +1524,54 @@
             "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
         },
         "node_modules/file-type": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/file-type/-/file-type-9.0.0.tgz",
-            "integrity": "sha512-Qe/5NJrgIOlwijpq3B7BEpzPFcgzggOTagZmkXQY4LA6bsXKTUstK7Wp12lEJ/mLKTpvIZxmIuRcLYWT6ov9lw==",
+            "version": "16.5.4",
+            "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
+            "integrity": "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==",
+            "license": "MIT",
+            "dependencies": {
+                "readable-web-to-node-stream": "^3.0.0",
+                "strtok3": "^6.2.4",
+                "token-types": "^4.1.1"
+            },
             "engines": {
-                "node": ">=6"
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/file-type?sponsor=1"
             }
         },
         "node_modules/finalhandler": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
-            "integrity": "sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+            "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+            "license": "MIT",
             "dependencies": {
-                "debug": "2.6.9",
-                "encodeurl": "~1.0.2",
-                "escape-html": "~1.0.3",
-                "on-finished": "2.4.1",
-                "parseurl": "~1.3.3",
-                "statuses": "2.0.1",
-                "unpipe": "~1.0.0"
+                "debug": "^4.4.0",
+                "encodeurl": "^2.0.0",
+                "escape-html": "^1.0.3",
+                "on-finished": "^2.4.1",
+                "parseurl": "^1.3.3",
+                "statuses": "^2.0.1"
             },
             "engines": {
-                "node": ">= 0.8"
+                "node": ">= 18.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/follow-redirects": {
-            "version": "1.15.1",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
-            "integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==",
+            "version": "1.15.11",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+            "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
             "funding": [
                 {
                     "type": "individual",
                     "url": "https://github.com/sponsors/RubenVerborgh"
                 }
             ],
+            "license": "MIT",
             "engines": {
                 "node": ">=4.0"
             },
@@ -898,64 +1612,55 @@
             }
         },
         "node_modules/fresh": {
-            "version": "0.5.2",
-            "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-            "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+            "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+            "license": "MIT",
             "engines": {
-                "node": ">= 0.6"
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/fsevents": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+            "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
             }
         },
         "node_modules/function-bind": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
-        },
-        "node_modules/get-intrinsic": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
-            "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
-            "dependencies": {
-                "function-bind": "^1.1.1",
-                "has": "^1.0.3",
-                "has-symbols": "^1.0.1"
-            },
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+            "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+            "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/gifwrap": {
-            "version": "0.9.4",
-            "resolved": "https://registry.npmjs.org/gifwrap/-/gifwrap-0.9.4.tgz",
-            "integrity": "sha512-MDMwbhASQuVeD4JKd1fKgNgCRL3fGqMM4WaqpNhWO0JiMOAjbQdumbs4BbBZEy9/M00EHEjKN3HieVhCUlwjeQ==",
+        "node_modules/get-intrinsic": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+            "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+            "license": "MIT",
             "dependencies": {
-                "image-q": "^4.0.0",
-                "omggif": "^1.0.10"
-            }
-        },
-        "node_modules/global": {
-            "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
-            "integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
-            "dependencies": {
-                "min-document": "^2.19.0",
-                "process": "^0.11.10"
-            }
-        },
-        "node_modules/has": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-            "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-            "dependencies": {
-                "function-bind": "^1.1.1"
+                "call-bind-apply-helpers": "^1.0.2",
+                "es-define-property": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "es-object-atoms": "^1.1.1",
+                "function-bind": "^1.1.2",
+                "get-proto": "^1.0.1",
+                "gopd": "^1.2.0",
+                "has-symbols": "^1.1.0",
+                "hasown": "^2.0.2",
+                "math-intrinsics": "^1.1.0"
             },
-            "engines": {
-                "node": ">= 0.4.0"
-            }
-        },
-        "node_modules/has-symbols": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-            "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
             "engines": {
                 "node": ">= 0.4"
             },
@@ -963,30 +1668,127 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/http-errors": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-            "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+        "node_modules/get-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+            "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+            "license": "MIT",
             "dependencies": {
-                "depd": "2.0.0",
-                "inherits": "2.0.4",
-                "setprototypeof": "1.2.0",
-                "statuses": "2.0.1",
-                "toidentifier": "1.0.1"
+                "dunder-proto": "^1.0.1",
+                "es-object-atoms": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/get-tsconfig": {
+            "version": "4.13.6",
+            "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
+            "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "resolve-pkg-maps": "^1.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+            }
+        },
+        "node_modules/gifwrap": {
+            "version": "0.10.1",
+            "resolved": "https://registry.npmjs.org/gifwrap/-/gifwrap-0.10.1.tgz",
+            "integrity": "sha512-2760b1vpJHNmLzZ/ubTtNnEx5WApN/PYWJvXvgS+tL1egTTthayFYIQQNi136FLEDcN/IyEY2EcGpIITD6eYUw==",
+            "license": "MIT",
+            "dependencies": {
+                "image-q": "^4.0.0",
+                "omggif": "^1.0.10"
+            }
+        },
+        "node_modules/gopd": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+            "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/has-symbols": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+            "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/has-tostringtag": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+            "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+            "license": "MIT",
+            "dependencies": {
+                "has-symbols": "^1.0.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/hasown": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+            "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+            "license": "MIT",
+            "dependencies": {
+                "function-bind": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/http-errors": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+            "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+            "license": "MIT",
+            "dependencies": {
+                "depd": "~2.0.0",
+                "inherits": "~2.0.4",
+                "setprototypeof": "~1.2.0",
+                "statuses": "~2.0.2",
+                "toidentifier": "~1.0.1"
             },
             "engines": {
                 "node": ">= 0.8"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/iconv-lite": {
-            "version": "0.4.24",
-            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-            "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+            "version": "0.7.2",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+            "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+            "license": "MIT",
             "dependencies": {
-                "safer-buffer": ">= 2.1.2 < 3"
+                "safer-buffer": ">= 2.1.2 < 3.0.0"
             },
             "engines": {
                 "node": ">=0.10.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/ieee754": {
@@ -1006,12 +1808,14 @@
                     "type": "consulting",
                     "url": "https://feross.org/support"
                 }
-            ]
+            ],
+            "license": "BSD-3-Clause"
         },
         "node_modules/image-q": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/image-q/-/image-q-4.0.0.tgz",
             "integrity": "sha512-PfJGVgIfKQJuq3s0tTDOKtztksibuUEbJQIYT3by6wctQo+Rdlh7ef4evJ5NCdxY4CfMbvFkocEwbl4BF8RlJw==",
+            "license": "MIT",
             "dependencies": {
                 "@types/node": "16.9.1"
             }
@@ -1019,7 +1823,8 @@
         "node_modules/image-q/node_modules/@types/node": {
             "version": "16.9.1",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.1.tgz",
-            "integrity": "sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g=="
+            "integrity": "sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g==",
+            "license": "MIT"
         },
         "node_modules/inherits": {
             "version": "2.0.4",
@@ -1034,30 +1839,27 @@
                 "node": ">= 0.10"
             }
         },
-        "node_modules/is-function": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.2.tgz",
-            "integrity": "sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ=="
+        "node_modules/is-promise": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+            "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+            "license": "MIT"
+        },
+        "node_modules/isomorphic-fetch": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
+            "integrity": "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==",
+            "license": "MIT",
+            "dependencies": {
+                "node-fetch": "^2.6.1",
+                "whatwg-fetch": "^3.4.1"
+            }
         },
         "node_modules/jpeg-js": {
-            "version": "0.4.2",
-            "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.2.tgz",
-            "integrity": "sha512-+az2gi/hvex7eLTMTlbRLOhH6P6WFdk2ITI8HJsaH2VqYO0I594zXSYEP+tf4FW+8Cy68ScDXoAsQdyQanv3sw=="
-        },
-        "node_modules/load-bmfont": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/load-bmfont/-/load-bmfont-1.4.1.tgz",
-            "integrity": "sha512-8UyQoYmdRDy81Brz6aLAUhfZLwr5zV0L3taTQ4hju7m6biuwiWiJXjPhBJxbUQJA8PrkvJ/7Enqmwk2sM14soA==",
-            "dependencies": {
-                "buffer-equal": "0.0.1",
-                "mime": "^1.3.4",
-                "parse-bmfont-ascii": "^1.0.3",
-                "parse-bmfont-binary": "^1.0.5",
-                "parse-bmfont-xml": "^1.1.4",
-                "phin": "^2.9.1",
-                "xhr": "^2.0.1",
-                "xtend": "^4.0.0"
-            }
+            "version": "0.4.4",
+            "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.4.tgz",
+            "integrity": "sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==",
+            "license": "BSD-3-Clause"
         },
         "node_modules/lru-cache": {
             "version": "6.0.0",
@@ -1081,18 +1883,35 @@
             "resolved": "https://registry.npmjs.org/marvinj/-/marvinj-1.0.0.tgz",
             "integrity": "sha512-+afDa86Pml2BlDt2lEn+xZUZ6r4q+aQvxSmWq37M4lQ4SraBJcKlbm+wDamzXTvW7OmeK0mkWdjRB4R3PAPFjA=="
         },
-        "node_modules/media-typer": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-            "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
+        "node_modules/math-intrinsics": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+            "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+            "license": "MIT",
             "engines": {
-                "node": ">= 0.6"
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/media-typer": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+            "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
             }
         },
         "node_modules/merge-descriptors": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-            "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+            "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
         },
         "node_modules/methods": {
             "version": "1.1.2",
@@ -1100,17 +1919,6 @@
             "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
             "engines": {
                 "node": ">= 0.6"
-            }
-        },
-        "node_modules/mime": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-            "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-            "bin": {
-                "mime": "cli.js"
-            },
-            "engines": {
-                "node": ">=4"
             }
         },
         "node_modules/mime-db": {
@@ -1132,74 +1940,76 @@
                 "node": ">= 0.6"
             }
         },
-        "node_modules/min-document": {
-            "version": "2.19.0",
-            "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
-            "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
-            "dependencies": {
-                "dom-walk": "^0.1.0"
-            }
-        },
-        "node_modules/minimist": {
-            "version": "1.2.6",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-            "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
-        },
-        "node_modules/mkdirp": {
-            "version": "0.5.6",
-            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-            "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-            "dependencies": {
-                "minimist": "^1.2.6"
-            },
-            "bin": {
-                "mkdirp": "bin/cmd.js"
-            }
-        },
         "node_modules/ms": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+            "license": "MIT"
         },
         "node_modules/negotiator": {
-            "version": "0.6.3",
-            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
-            "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+            "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
             }
         },
-        "node_modules/node-vibrant": {
-            "version": "3.2.1-alpha.1",
-            "resolved": "https://registry.npmjs.org/node-vibrant/-/node-vibrant-3.2.1-alpha.1.tgz",
-            "integrity": "sha512-EQergCp7fvbvUCE0VMCBnvaAV0lGWSP8SXLmuWQIBzQK5M5pIwcd9fIOXuzFkJx/8hUiiiLvAzzGDS/bIy2ikA==",
+        "node_modules/node-fetch": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+            "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+            "license": "MIT",
             "dependencies": {
-                "@types/node": "^10.12.18",
-                "@vibrant/core": "^3.2.1-alpha.1",
-                "@vibrant/generator-default": "^3.2.1-alpha.1",
-                "@vibrant/image-browser": "^3.2.1-alpha.1",
-                "@vibrant/image-node": "^3.2.1-alpha.1",
-                "@vibrant/quantizer-mmcq": "^3.2.1-alpha.1",
-                "url": "^0.11.0"
+                "whatwg-url": "^5.0.0"
+            },
+            "engines": {
+                "node": "4.x || >=6.0.0"
+            },
+            "peerDependencies": {
+                "encoding": "^0.1.0"
+            },
+            "peerDependenciesMeta": {
+                "encoding": {
+                    "optional": true
+                }
             }
         },
-        "node_modules/node-vibrant/node_modules/@types/node": {
-            "version": "10.17.60",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
-            "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
+        "node_modules/node-vibrant": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/node-vibrant/-/node-vibrant-4.0.4.tgz",
+            "integrity": "sha512-hA/pUXBE9TJ41G9FlTkzeqD5JdxgvvPGYZb/HNpdkaxxXUEnP36imSolZ644JuPun+lTd+FpWWtBpTYdp2noQA==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "^18.15.3",
+                "@vibrant/core": "^4.0.4",
+                "@vibrant/generator-default": "^4.0.4",
+                "@vibrant/image-browser": "^4.0.4",
+                "@vibrant/image-node": "^4.0.4",
+                "@vibrant/quantizer-mmcq": "^4.0.4"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/crutchcorn"
+            }
         },
         "node_modules/object-assign": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+            "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+            "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
             }
         },
         "node_modules/object-inspect": {
-            "version": "1.12.0",
-            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
-            "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==",
+            "version": "1.13.4",
+            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+            "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
@@ -1207,12 +2017,14 @@
         "node_modules/omggif": {
             "version": "1.0.10",
             "resolved": "https://registry.npmjs.org/omggif/-/omggif-1.0.10.tgz",
-            "integrity": "sha512-LMJTtvgc/nugXj0Vcrrs68Mn2D1r0zf630VNtqtpI1FEO7e+O9FP4gqs9AcnBaSEeoHIPm28u6qgPR0oyEpGSw=="
+            "integrity": "sha512-LMJTtvgc/nugXj0Vcrrs68Mn2D1r0zf630VNtqtpI1FEO7e+O9FP4gqs9AcnBaSEeoHIPm28u6qgPR0oyEpGSw==",
+            "license": "MIT"
         },
         "node_modules/on-finished": {
             "version": "2.4.1",
             "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
             "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+            "license": "MIT",
             "dependencies": {
                 "ee-first": "1.1.1"
             },
@@ -1220,57 +2032,58 @@
                 "node": ">= 0.8"
             }
         },
+        "node_modules/once": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+            "license": "ISC",
+            "dependencies": {
+                "wrappy": "1"
+            }
+        },
         "node_modules/pako": {
             "version": "1.0.11",
             "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-            "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
-        },
-        "node_modules/parse-bmfont-ascii": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/parse-bmfont-ascii/-/parse-bmfont-ascii-1.0.6.tgz",
-            "integrity": "sha1-Eaw8P/WPfCAgqyJ2kHkQjU36AoU="
-        },
-        "node_modules/parse-bmfont-binary": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/parse-bmfont-binary/-/parse-bmfont-binary-1.0.6.tgz",
-            "integrity": "sha1-0Di0dtPp3Z2x4RoLDlOiJ5K2kAY="
-        },
-        "node_modules/parse-bmfont-xml": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/parse-bmfont-xml/-/parse-bmfont-xml-1.1.4.tgz",
-            "integrity": "sha512-bjnliEOmGv3y1aMEfREMBJ9tfL3WR0i0CKPj61DnSLaoxWR3nLrsQrEbCId/8rF4NyRF0cCqisSVXyQYWM+mCQ==",
-            "dependencies": {
-                "xml-parse-from-string": "^1.0.0",
-                "xml2js": "^0.4.5"
-            }
-        },
-        "node_modules/parse-headers": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.5.tgz",
-            "integrity": "sha512-ft3iAoLOB/MlwbNXgzy43SWGP6sQki2jQvAyBg/zDFAgr9bfNWZIUj42Kw2eJIl8kEi4PbgE6U1Zau/HwI75HA=="
+            "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+            "license": "(MIT AND Zlib)"
         },
         "node_modules/parseurl": {
             "version": "1.3.3",
             "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
             "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
             }
         },
         "node_modules/path-to-regexp": {
-            "version": "0.1.7",
-            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-            "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+            "version": "8.3.0",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+            "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+            "license": "MIT",
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
         },
-        "node_modules/phin": {
-            "version": "2.9.3",
-            "resolved": "https://registry.npmjs.org/phin/-/phin-2.9.3.tgz",
-            "integrity": "sha512-CzFr90qM24ju5f88quFC/6qohjC144rehe5n6DH900lgXmUe86+xCKc10ev56gRKC4/BkHUoG4uSiQgBiIXwDA=="
+        "node_modules/peek-readable": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-4.1.0.tgz",
+            "integrity": "sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Borewit"
+            }
         },
         "node_modules/pixelmatch": {
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-4.0.2.tgz",
-            "integrity": "sha1-j0fc7FARtHe2fbA8JDvB8wheiFQ=",
+            "integrity": "sha512-J8B6xqiO37sU/gkcMglv6h5Jbd9xNER7aHzpfRdNmV4IbQBzBpe4l9XmbG+xPF/znacgu2jfEw+wHffaq/YkXA==",
+            "license": "ISC",
             "dependencies": {
                 "pngjs": "^3.0.0"
             },
@@ -1278,12 +2091,22 @@
                 "pixelmatch": "bin/pixelmatch"
             }
         },
-        "node_modules/pngjs": {
+        "node_modules/pixelmatch/node_modules/pngjs": {
             "version": "3.4.0",
             "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.4.0.tgz",
             "integrity": "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==",
+            "license": "MIT",
             "engines": {
                 "node": ">=4.0.0"
+            }
+        },
+        "node_modules/pngjs": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-6.0.0.tgz",
+            "integrity": "sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=12.13.0"
             }
         },
         "node_modules/prettier": {
@@ -1304,7 +2127,8 @@
         "node_modules/process": {
             "version": "0.11.10",
             "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-            "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
+            "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.6.0"
             }
@@ -1321,17 +2145,19 @@
                 "node": ">= 0.10"
             }
         },
-        "node_modules/punycode": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-            "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+        "node_modules/proxy-from-env": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+            "license": "MIT"
         },
         "node_modules/qs": {
-            "version": "6.10.3",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
-            "integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
+            "version": "6.15.0",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+            "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+            "license": "BSD-3-Clause",
             "dependencies": {
-                "side-channel": "^1.0.4"
+                "side-channel": "^1.1.0"
             },
             "engines": {
                 "node": ">=0.6"
@@ -1340,35 +2166,28 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/querystring": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-            "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
-            "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
-            "engines": {
-                "node": ">=0.4.x"
-            }
-        },
         "node_modules/range-parser": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
             "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
             }
         },
         "node_modules/raw-body": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
-            "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+            "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+            "license": "MIT",
             "dependencies": {
-                "bytes": "3.1.2",
-                "http-errors": "2.0.0",
-                "iconv-lite": "0.4.24",
-                "unpipe": "1.0.0"
+                "bytes": "~3.1.2",
+                "http-errors": "~2.0.1",
+                "iconv-lite": "~0.7.0",
+                "unpipe": "~1.0.0"
             },
             "engines": {
-                "node": ">= 0.8"
+                "node": ">= 0.10"
             }
         },
         "node_modules/readable-stream": {
@@ -1384,10 +2203,93 @@
                 "node": ">= 6"
             }
         },
+        "node_modules/readable-web-to-node-stream": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.4.tgz",
+            "integrity": "sha512-9nX56alTf5bwXQ3ZDipHJhusu9NTQJ/CVPtb/XHAJCXihZeitfJvIRS4GqQ/mfIoOE3IelHMrpayVrosdHBuLw==",
+            "license": "MIT",
+            "dependencies": {
+                "readable-stream": "^4.7.0"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Borewit"
+            }
+        },
+        "node_modules/readable-web-to-node-stream/node_modules/buffer": {
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+            "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "base64-js": "^1.3.1",
+                "ieee754": "^1.2.1"
+            }
+        },
+        "node_modules/readable-web-to-node-stream/node_modules/readable-stream": {
+            "version": "4.7.0",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+            "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+            "license": "MIT",
+            "dependencies": {
+                "abort-controller": "^3.0.0",
+                "buffer": "^6.0.3",
+                "events": "^3.3.0",
+                "process": "^0.11.10",
+                "string_decoder": "^1.3.0"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            }
+        },
         "node_modules/regenerator-runtime": {
-            "version": "0.13.9",
-            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-            "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
+            "version": "0.13.11",
+            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+            "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+            "license": "MIT"
+        },
+        "node_modules/resolve-pkg-maps": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+            "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+            }
+        },
+        "node_modules/router": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+            "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.4.0",
+                "depd": "^2.0.0",
+                "is-promise": "^4.0.0",
+                "parseurl": "^1.3.3",
+                "path-to-regexp": "^8.0.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            }
         },
         "node_modules/safe-buffer": {
             "version": "5.2.1",
@@ -1411,7 +2313,8 @@
         "node_modules/safer-buffer": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+            "license": "MIT"
         },
         "node_modules/sax": {
             "version": "1.2.4",
@@ -1433,162 +2336,240 @@
             }
         },
         "node_modules/send": {
-            "version": "0.18.0",
-            "resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
-            "integrity": "sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+            "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+            "license": "MIT",
             "dependencies": {
-                "debug": "2.6.9",
-                "depd": "2.0.0",
-                "destroy": "1.2.0",
-                "encodeurl": "~1.0.2",
-                "escape-html": "~1.0.3",
-                "etag": "~1.8.1",
-                "fresh": "0.5.2",
-                "http-errors": "2.0.0",
-                "mime": "1.6.0",
-                "ms": "2.1.3",
-                "on-finished": "2.4.1",
-                "range-parser": "~1.2.1",
-                "statuses": "2.0.1"
+                "debug": "^4.4.3",
+                "encodeurl": "^2.0.0",
+                "escape-html": "^1.0.3",
+                "etag": "^1.8.1",
+                "fresh": "^2.0.0",
+                "http-errors": "^2.0.1",
+                "mime-types": "^3.0.2",
+                "ms": "^2.1.3",
+                "on-finished": "^2.4.1",
+                "range-parser": "^1.2.1",
+                "statuses": "^2.0.2"
             },
             "engines": {
-                "node": ">= 0.8.0"
+                "node": ">= 18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
-        "node_modules/send/node_modules/ms": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+        "node_modules/send/node_modules/mime-db": {
+            "version": "1.54.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+            "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
         },
-        "node_modules/serve-static": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.15.0.tgz",
-            "integrity": "sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==",
+        "node_modules/send/node_modules/mime-types": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+            "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+            "license": "MIT",
             "dependencies": {
-                "encodeurl": "~1.0.2",
-                "escape-html": "~1.0.3",
-                "parseurl": "~1.3.3",
-                "send": "0.18.0"
+                "mime-db": "^1.54.0"
             },
             "engines": {
-                "node": ">= 0.8.0"
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/serve-static": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+            "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+            "license": "MIT",
+            "dependencies": {
+                "encodeurl": "^2.0.0",
+                "escape-html": "^1.0.3",
+                "parseurl": "^1.3.3",
+                "send": "^1.2.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/setprototypeof": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
-            "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
+            "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+            "license": "ISC"
         },
         "node_modules/shairport-sync-reader": {
             "version": "0.0.9",
             "resolved": "https://registry.npmjs.org/shairport-sync-reader/-/shairport-sync-reader-0.0.9.tgz",
             "integrity": "sha512-bY0fAj39MUhFa+qTJVVZMD9FUVe/IBpG2YDiSGWY8HWdiUZzaLJ1i8guP+K7AHOawrGxBCYXOu34CFqod3K2aQ==",
+            "license": "MIT",
             "dependencies": {
                 "daap-parser": "^0.1.1",
                 "xml2js": "^0.4.17"
             }
         },
         "node_modules/side-channel": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
-            "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+            "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+            "license": "MIT",
             "dependencies": {
-                "call-bind": "^1.0.0",
-                "get-intrinsic": "^1.0.2",
-                "object-inspect": "^1.9.0"
+                "es-errors": "^1.3.0",
+                "object-inspect": "^1.13.3",
+                "side-channel-list": "^1.0.0",
+                "side-channel-map": "^1.0.1",
+                "side-channel-weakmap": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/side-channel-list": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+            "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "object-inspect": "^1.13.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/side-channel-map": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+            "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.2",
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.5",
+                "object-inspect": "^1.13.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/side-channel-weakmap": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+            "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.2",
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.5",
+                "object-inspect": "^1.13.3",
+                "side-channel-map": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/socket.io": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.5.0.tgz",
-            "integrity": "sha512-slTYqU2jCgMjXwresG8grhUi/cC6GjzmcfqArzaH3BN/9I/42eZk9yamNvZJdBfTubkjEdKAKs12NEztId+bUA==",
+            "version": "4.8.3",
+            "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.8.3.tgz",
+            "integrity": "sha512-2Dd78bqzzjE6KPkD5fHZmDAKRNe3J15q+YHDrIsy9WEkqttc7GY+kT9OBLSMaPbQaEd0x1BjcmtMtXkfpc+T5A==",
+            "license": "MIT",
             "dependencies": {
                 "accepts": "~1.3.4",
                 "base64id": "~2.0.0",
-                "debug": "~4.3.2",
-                "engine.io": "~6.2.0",
-                "socket.io-adapter": "~2.4.0",
-                "socket.io-parser": "~4.0.4"
+                "cors": "~2.8.5",
+                "debug": "~4.4.1",
+                "engine.io": "~6.6.0",
+                "socket.io-adapter": "~2.5.2",
+                "socket.io-parser": "~4.2.4"
             },
             "engines": {
-                "node": ">=10.0.0"
+                "node": ">=10.2.0"
             }
         },
         "node_modules/socket.io-adapter": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.4.0.tgz",
-            "integrity": "sha512-W4N+o69rkMEGVuk2D/cvca3uYsvGlMwsySWV447y99gUPghxq42BxqLNMndb+a1mm/5/7NeXVQS7RLa2XyXvYg=="
+            "version": "2.5.6",
+            "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.6.tgz",
+            "integrity": "sha512-DkkO/dz7MGln0dHn5bmN3pPy+JmywNICWrJqVWiVOyvXjWQFIv9c2h24JrQLLFJ2aQVQf/Cvl1vblnd4r2apLQ==",
+            "license": "MIT",
+            "dependencies": {
+                "debug": "~4.4.1",
+                "ws": "~8.18.3"
+            }
         },
         "node_modules/socket.io-parser": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.0.4.tgz",
-            "integrity": "sha512-t+b0SS+IxG7Rxzda2EVvyBZbvFPBCjJoyHuE0P//7OAsN23GItzDRdWa6ALxZI/8R5ygK7jAR6t028/z+7295g==",
+            "version": "4.2.5",
+            "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.5.tgz",
+            "integrity": "sha512-bPMmpy/5WWKHea5Y/jYAP6k74A+hvmRCQaJuJB6I/ML5JZq/KfNieUVo/3Mh7SAqn7TyFdIo6wqYHInG1MU1bQ==",
+            "license": "MIT",
             "dependencies": {
-                "@types/component-emitter": "^1.2.10",
-                "component-emitter": "~1.3.0",
-                "debug": "~4.3.1"
+                "@socket.io/component-emitter": "~3.1.0",
+                "debug": "~4.4.1"
             },
             "engines": {
                 "node": ">=10.0.0"
             }
         },
-        "node_modules/socket.io-parser/node_modules/debug": {
-            "version": "4.3.4",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+        "node_modules/socket.io/node_modules/accepts": {
+            "version": "1.3.8",
+            "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+            "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+            "license": "MIT",
             "dependencies": {
-                "ms": "2.1.2"
+                "mime-types": "~2.1.34",
+                "negotiator": "0.6.3"
             },
             "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
+                "node": ">= 0.6"
             }
         },
-        "node_modules/socket.io-parser/node_modules/ms": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        },
-        "node_modules/socket.io/node_modules/debug": {
-            "version": "4.3.4",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-            "dependencies": {
-                "ms": "2.1.2"
-            },
+        "node_modules/socket.io/node_modules/negotiator": {
+            "version": "0.6.3",
+            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+            "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+            "license": "MIT",
             "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
+                "node": ">= 0.6"
             }
-        },
-        "node_modules/socket.io/node_modules/ms": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "node_modules/spotify-web-api-node": {
             "version": "5.0.2",
             "resolved": "https://registry.npmjs.org/spotify-web-api-node/-/spotify-web-api-node-5.0.2.tgz",
             "integrity": "sha512-r82dRWU9PMimHvHEzL0DwEJrzFk+SMCVfq249SLt3I7EFez7R+jeoKQd+M1//QcnjqlXPs2am4DFsGk8/GCsrA==",
+            "license": "MIT",
             "dependencies": {
                 "superagent": "^6.1.0"
             }
         },
         "node_modules/statuses": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-            "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+            "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
             }
@@ -1599,6 +2580,23 @@
             "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
             "dependencies": {
                 "safe-buffer": "~5.2.0"
+            }
+        },
+        "node_modules/strtok3": {
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.3.0.tgz",
+            "integrity": "sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw==",
+            "license": "MIT",
+            "dependencies": {
+                "@tokenizer/token": "^0.3.0",
+                "peek-readable": "^4.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Borewit"
             }
         },
         "node_modules/superagent": {
@@ -1623,22 +2621,6 @@
                 "node": ">= 7.0.0"
             }
         },
-        "node_modules/superagent/node_modules/debug": {
-            "version": "4.3.4",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-            "dependencies": {
-                "ms": "2.1.2"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/superagent/node_modules/mime": {
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
@@ -1650,37 +2632,56 @@
                 "node": ">=4.0.0"
             }
         },
-        "node_modules/superagent/node_modules/ms": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        },
         "node_modules/timm": {
             "version": "1.7.1",
             "resolved": "https://registry.npmjs.org/timm/-/timm-1.7.1.tgz",
-            "integrity": "sha512-IjZc9KIotudix8bMaBW6QvMuq64BrJWFs1+4V0lXwWGQZwH+LnX87doAYhem4caOEusRP9/g6jVDQmZ8XOk1nw=="
+            "integrity": "sha512-IjZc9KIotudix8bMaBW6QvMuq64BrJWFs1+4V0lXwWGQZwH+LnX87doAYhem4caOEusRP9/g6jVDQmZ8XOk1nw==",
+            "license": "MIT"
         },
         "node_modules/tinycolor2": {
-            "version": "1.4.2",
-            "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.2.tgz",
-            "integrity": "sha512-vJhccZPs965sV/L2sU4oRQVAos0pQXwsvTLkWYdqJ+a8Q5kPFzJTuOFwy7UniPli44NKQGAglksjvOcpo95aZA==",
-            "engines": {
-                "node": "*"
-            }
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
+            "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==",
+            "license": "MIT"
         },
         "node_modules/toidentifier": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
             "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+            "license": "MIT",
             "engines": {
                 "node": ">=0.6"
             }
         },
+        "node_modules/token-types": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/token-types/-/token-types-4.2.1.tgz",
+            "integrity": "sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@tokenizer/token": "^0.3.0",
+                "ieee754": "^1.2.1"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Borewit"
+            }
+        },
+        "node_modules/tr46": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+            "license": "MIT"
+        },
         "node_modules/ts-node": {
-            "version": "10.8.1",
-            "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.8.1.tgz",
-            "integrity": "sha512-Wwsnao4DQoJsN034wePSg5nZiw4YKXf56mPIAeD6wVmiv+RytNSWqc2f3fKvcUoV+Yn2+yocD71VOfQHbmVX4g==",
+            "version": "10.9.2",
+            "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+            "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@cspotcode/source-map-support": "^0.8.0",
                 "@tsconfig/node10": "^1.0.7",
@@ -1719,16 +2720,63 @@
                 }
             }
         },
-        "node_modules/type-is": {
-            "version": "1.6.18",
-            "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
-            "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+        "node_modules/tsx": {
+            "version": "4.21.0",
+            "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+            "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+            "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "media-typer": "0.3.0",
-                "mime-types": "~2.1.24"
+                "esbuild": "~0.27.0",
+                "get-tsconfig": "^4.7.5"
+            },
+            "bin": {
+                "tsx": "dist/cli.mjs"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            },
+            "optionalDependencies": {
+                "fsevents": "~2.3.3"
+            }
+        },
+        "node_modules/type-is": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+            "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+            "license": "MIT",
+            "dependencies": {
+                "content-type": "^1.0.5",
+                "media-typer": "^1.1.0",
+                "mime-types": "^3.0.0"
             },
             "engines": {
                 "node": ">= 0.6"
+            }
+        },
+        "node_modules/type-is/node_modules/mime-db": {
+            "version": "1.54.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+            "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/type-is/node_modules/mime-types": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+            "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+            "license": "MIT",
+            "dependencies": {
+                "mime-db": "^1.54.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/typescript": {
@@ -1744,43 +2792,34 @@
                 "node": ">=4.2.0"
             }
         },
+        "node_modules/undici-types": {
+            "version": "5.26.5",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+            "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+            "license": "MIT"
+        },
         "node_modules/unpipe": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-            "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+            "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
             }
         },
-        "node_modules/url": {
-            "version": "0.11.0",
-            "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
-            "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
+        "node_modules/utif2": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/utif2/-/utif2-4.1.0.tgz",
+            "integrity": "sha512-+oknB9FHrJ7oW7A2WZYajOcv4FcDR4CfoGB0dPNfxbi4GO05RRnFmt5oa23+9w32EanrYcSJWspUiJkLMs+37w==",
+            "license": "MIT",
             "dependencies": {
-                "punycode": "1.3.2",
-                "querystring": "0.2.0"
-            }
-        },
-        "node_modules/utif": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/utif/-/utif-2.0.1.tgz",
-            "integrity": "sha512-Z/S1fNKCicQTf375lIP9G8Sa1H/phcysstNrrSdZKj1f9g58J4NMgb5IgiEZN9/nLMPDwF0W7hdOe9Qq2IYoLg==",
-            "dependencies": {
-                "pako": "^1.0.5"
+                "pako": "^1.0.11"
             }
         },
         "node_modules/util-deprecate": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
             "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
-        },
-        "node_modules/utils-merge": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-            "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
-            "engines": {
-                "node": ">= 0.4.0"
-            }
         },
         "node_modules/v8-compile-cache-lib": {
             "version": "3.0.1",
@@ -1796,16 +2835,45 @@
                 "node": ">= 0.8"
             }
         },
+        "node_modules/webidl-conversions": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+            "license": "BSD-2-Clause"
+        },
+        "node_modules/whatwg-fetch": {
+            "version": "3.6.20",
+            "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
+            "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==",
+            "license": "MIT"
+        },
+        "node_modules/whatwg-url": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+            "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+            "license": "MIT",
+            "dependencies": {
+                "tr46": "~0.0.3",
+                "webidl-conversions": "^3.0.0"
+            }
+        },
+        "node_modules/wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+            "license": "ISC"
+        },
         "node_modules/ws": {
-            "version": "8.2.3",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
-            "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
+            "version": "8.18.3",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+            "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+            "license": "MIT",
             "engines": {
                 "node": ">=10.0.0"
             },
             "peerDependencies": {
                 "bufferutil": "^4.0.1",
-                "utf-8-validate": "^5.0.2"
+                "utf-8-validate": ">=5.0.2"
             },
             "peerDependenciesMeta": {
                 "bufferutil": {
@@ -1815,22 +2883,6 @@
                     "optional": true
                 }
             }
-        },
-        "node_modules/xhr": {
-            "version": "2.6.0",
-            "resolved": "https://registry.npmjs.org/xhr/-/xhr-2.6.0.tgz",
-            "integrity": "sha512-/eCGLb5rxjx5e3mF1A7s+pLlR6CGyqWN91fv1JgER5mVWg1MZmlhBvy9kjcsOdRk8RrIujotWyJamfyrp+WIcA==",
-            "dependencies": {
-                "global": "~4.4.0",
-                "is-function": "^1.0.1",
-                "parse-headers": "^2.0.0",
-                "xtend": "^4.0.0"
-            }
-        },
-        "node_modules/xml-parse-from-string": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/xml-parse-from-string/-/xml-parse-from-string-1.0.1.tgz",
-            "integrity": "sha1-qQKekp09vN7RafPG4oI42VpdWig="
         },
         "node_modules/xml2js": {
             "version": "0.4.23",
@@ -1852,14 +2904,6 @@
                 "node": ">=4.0"
             }
         },
-        "node_modules/xtend": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-            "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-            "engines": {
-                "node": ">=0.4"
-            }
-        },
         "node_modules/yallist": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
@@ -1876,14 +2920,6 @@
         }
     },
     "dependencies": {
-        "@babel/runtime": {
-            "version": "7.18.3",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.3.tgz",
-            "integrity": "sha512-38Y8f7YUhce/K7RMwTp7m0uCumpv9hZkitCbBClqQIow1qSbCvGkcegKOXpEWCQLfWmevgRiWokZ1GkpfhbZug==",
-            "requires": {
-                "regenerator-runtime": "^0.13.4"
-            }
-        },
         "@check-light-or-dark/image": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/@check-light-or-dark/image/-/image-1.0.4.tgz",
@@ -1906,112 +2942,282 @@
                 "@jridgewell/trace-mapping": "0.3.9"
             }
         },
+        "@esbuild/aix-ppc64": {
+            "version": "0.27.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+            "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/android-arm": {
+            "version": "0.27.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+            "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/android-arm64": {
+            "version": "0.27.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+            "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/android-x64": {
+            "version": "0.27.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+            "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/darwin-arm64": {
+            "version": "0.27.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+            "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/darwin-x64": {
+            "version": "0.27.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+            "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/freebsd-arm64": {
+            "version": "0.27.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+            "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/freebsd-x64": {
+            "version": "0.27.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+            "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/linux-arm": {
+            "version": "0.27.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+            "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/linux-arm64": {
+            "version": "0.27.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+            "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/linux-ia32": {
+            "version": "0.27.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+            "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/linux-loong64": {
+            "version": "0.27.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+            "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/linux-mips64el": {
+            "version": "0.27.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+            "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/linux-ppc64": {
+            "version": "0.27.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+            "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/linux-riscv64": {
+            "version": "0.27.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+            "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/linux-s390x": {
+            "version": "0.27.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+            "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/linux-x64": {
+            "version": "0.27.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+            "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/netbsd-arm64": {
+            "version": "0.27.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+            "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/netbsd-x64": {
+            "version": "0.27.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+            "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/openbsd-arm64": {
+            "version": "0.27.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+            "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/openbsd-x64": {
+            "version": "0.27.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+            "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/openharmony-arm64": {
+            "version": "0.27.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+            "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/sunos-x64": {
+            "version": "0.27.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+            "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/win32-arm64": {
+            "version": "0.27.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+            "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/win32-ia32": {
+            "version": "0.27.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+            "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/win32-x64": {
+            "version": "0.27.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+            "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+            "dev": true,
+            "optional": true
+        },
         "@jimp/bmp": {
-            "version": "0.16.1",
-            "resolved": "https://registry.npmjs.org/@jimp/bmp/-/bmp-0.16.1.tgz",
-            "integrity": "sha512-iwyNYQeBawrdg/f24x3pQ5rEx+/GwjZcCXd3Kgc+ZUd+Ivia7sIqBsOnDaMZdKCBPlfW364ekexnlOqyVa0NWg==",
+            "version": "0.22.12",
+            "resolved": "https://registry.npmjs.org/@jimp/bmp/-/bmp-0.22.12.tgz",
+            "integrity": "sha512-aeI64HD0npropd+AR76MCcvvRaa+Qck6loCOS03CkkxGHN5/r336qTM5HPUdHKMDOGzqknuVPA8+kK1t03z12g==",
             "requires": {
-                "@babel/runtime": "^7.7.2",
-                "@jimp/utils": "^0.16.1",
+                "@jimp/utils": "^0.22.12",
                 "bmp-js": "^0.1.0"
             }
         },
         "@jimp/core": {
-            "version": "0.16.1",
-            "resolved": "https://registry.npmjs.org/@jimp/core/-/core-0.16.1.tgz",
-            "integrity": "sha512-la7kQia31V6kQ4q1kI/uLimu8FXx7imWVajDGtwUG8fzePLWDFJyZl0fdIXVCL1JW2nBcRHidUot6jvlRDi2+g==",
+            "version": "0.22.12",
+            "resolved": "https://registry.npmjs.org/@jimp/core/-/core-0.22.12.tgz",
+            "integrity": "sha512-l0RR0dOPyzMKfjUW1uebzueFEDtCOj9fN6pyTYWWOM/VS4BciXQ1VVrJs8pO3kycGYZxncRKhCoygbNr8eEZQA==",
             "requires": {
-                "@babel/runtime": "^7.7.2",
-                "@jimp/utils": "^0.16.1",
+                "@jimp/utils": "^0.22.12",
                 "any-base": "^1.1.0",
                 "buffer": "^5.2.0",
                 "exif-parser": "^0.1.12",
-                "file-type": "^9.0.0",
-                "load-bmfont": "^1.3.1",
-                "mkdirp": "^0.5.1",
-                "phin": "^2.9.1",
+                "file-type": "^16.5.4",
+                "isomorphic-fetch": "^3.0.0",
                 "pixelmatch": "^4.0.2",
-                "tinycolor2": "^1.4.1"
+                "tinycolor2": "^1.6.0"
             }
         },
         "@jimp/custom": {
-            "version": "0.16.1",
-            "resolved": "https://registry.npmjs.org/@jimp/custom/-/custom-0.16.1.tgz",
-            "integrity": "sha512-DNUAHNSiUI/j9hmbatD6WN/EBIyeq4AO0frl5ETtt51VN1SvE4t4v83ZA/V6ikxEf3hxLju4tQ5Pc3zmZkN/3A==",
+            "version": "0.22.12",
+            "resolved": "https://registry.npmjs.org/@jimp/custom/-/custom-0.22.12.tgz",
+            "integrity": "sha512-xcmww1O/JFP2MrlGUMd3Q78S3Qu6W3mYTXYuIqFq33EorgYHV/HqymHfXy9GjiCJ7OI+7lWx6nYFOzU7M4rd1Q==",
             "requires": {
-                "@babel/runtime": "^7.7.2",
-                "@jimp/core": "^0.16.1"
+                "@jimp/core": "^0.22.12"
             }
         },
         "@jimp/gif": {
-            "version": "0.16.1",
-            "resolved": "https://registry.npmjs.org/@jimp/gif/-/gif-0.16.1.tgz",
-            "integrity": "sha512-r/1+GzIW1D5zrP4tNrfW+3y4vqD935WBXSc8X/wm23QTY9aJO9Lw6PEdzpYCEY+SOklIFKaJYUAq/Nvgm/9ryw==",
+            "version": "0.22.12",
+            "resolved": "https://registry.npmjs.org/@jimp/gif/-/gif-0.22.12.tgz",
+            "integrity": "sha512-y6BFTJgch9mbor2H234VSjd9iwAhaNf/t3US5qpYIs0TSbAvM02Fbc28IaDETj9+4YB4676sz4RcN/zwhfu1pg==",
             "requires": {
-                "@babel/runtime": "^7.7.2",
-                "@jimp/utils": "^0.16.1",
-                "gifwrap": "^0.9.2",
+                "@jimp/utils": "^0.22.12",
+                "gifwrap": "^0.10.1",
                 "omggif": "^1.0.9"
             }
         },
         "@jimp/jpeg": {
-            "version": "0.16.1",
-            "resolved": "https://registry.npmjs.org/@jimp/jpeg/-/jpeg-0.16.1.tgz",
-            "integrity": "sha512-8352zrdlCCLFdZ/J+JjBslDvml+fS3Z8gttdml0We759PnnZGqrnPRhkOEOJbNUlE+dD4ckLeIe6NPxlS/7U+w==",
+            "version": "0.22.12",
+            "resolved": "https://registry.npmjs.org/@jimp/jpeg/-/jpeg-0.22.12.tgz",
+            "integrity": "sha512-Rq26XC/uQWaQKyb/5lksCTCxXhtY01NJeBN+dQv5yNYedN0i7iYu+fXEoRsfaJ8xZzjoANH8sns7rVP4GE7d/Q==",
             "requires": {
-                "@babel/runtime": "^7.7.2",
-                "@jimp/utils": "^0.16.1",
-                "jpeg-js": "0.4.2"
+                "@jimp/utils": "^0.22.12",
+                "jpeg-js": "^0.4.4"
             }
         },
         "@jimp/plugin-resize": {
-            "version": "0.16.1",
-            "resolved": "https://registry.npmjs.org/@jimp/plugin-resize/-/plugin-resize-0.16.1.tgz",
-            "integrity": "sha512-u4JBLdRI7dargC04p2Ha24kofQBk3vhaf0q8FwSYgnCRwxfvh2RxvhJZk9H7Q91JZp6wgjz/SjvEAYjGCEgAwQ==",
+            "version": "0.22.12",
+            "resolved": "https://registry.npmjs.org/@jimp/plugin-resize/-/plugin-resize-0.22.12.tgz",
+            "integrity": "sha512-3NyTPlPbTnGKDIbaBgQ3HbE6wXbAlFfxHVERmrbqAi8R3r6fQPxpCauA8UVDnieg5eo04D0T8nnnNIX//i/sXg==",
             "requires": {
-                "@babel/runtime": "^7.7.2",
-                "@jimp/utils": "^0.16.1"
+                "@jimp/utils": "^0.22.12"
             }
         },
         "@jimp/png": {
-            "version": "0.16.1",
-            "resolved": "https://registry.npmjs.org/@jimp/png/-/png-0.16.1.tgz",
-            "integrity": "sha512-iyWoCxEBTW0OUWWn6SveD4LePW89kO7ZOy5sCfYeDM/oTPLpR8iMIGvZpZUz1b8kvzFr27vPst4E5rJhGjwsdw==",
+            "version": "0.22.12",
+            "resolved": "https://registry.npmjs.org/@jimp/png/-/png-0.22.12.tgz",
+            "integrity": "sha512-Mrp6dr3UTn+aLK8ty/dSKELz+Otdz1v4aAXzV5q53UDD2rbB5joKVJ/ChY310B+eRzNxIovbUF1KVrUsYdE8Hg==",
             "requires": {
-                "@babel/runtime": "^7.7.2",
-                "@jimp/utils": "^0.16.1",
-                "pngjs": "^3.3.3"
+                "@jimp/utils": "^0.22.12",
+                "pngjs": "^6.0.0"
             }
         },
         "@jimp/tiff": {
-            "version": "0.16.1",
-            "resolved": "https://registry.npmjs.org/@jimp/tiff/-/tiff-0.16.1.tgz",
-            "integrity": "sha512-3K3+xpJS79RmSkAvFMgqY5dhSB+/sxhwTFA9f4AVHUK0oKW+u6r52Z1L0tMXHnpbAdR9EJ+xaAl2D4x19XShkQ==",
+            "version": "0.22.12",
+            "resolved": "https://registry.npmjs.org/@jimp/tiff/-/tiff-0.22.12.tgz",
+            "integrity": "sha512-E1LtMh4RyJsoCAfAkBRVSYyZDTtLq9p9LUiiYP0vPtXyxX4BiYBUYihTLSBlCQg5nF2e4OpQg7SPrLdJ66u7jg==",
             "requires": {
-                "@babel/runtime": "^7.7.2",
-                "utif": "^2.0.1"
+                "utif2": "^4.0.1"
             }
         },
         "@jimp/types": {
-            "version": "0.16.1",
-            "resolved": "https://registry.npmjs.org/@jimp/types/-/types-0.16.1.tgz",
-            "integrity": "sha512-g1w/+NfWqiVW4CaXSJyD28JQqZtm2eyKMWPhBBDCJN9nLCN12/Az0WFF3JUAktzdsEC2KRN2AqB1a2oMZBNgSQ==",
+            "version": "0.22.12",
+            "resolved": "https://registry.npmjs.org/@jimp/types/-/types-0.22.12.tgz",
+            "integrity": "sha512-wwKYzRdElE1MBXFREvCto5s699izFHNVvALUv79GXNbsOVqlwlOxlWJ8DuyOGIXoLP4JW/m30YyuTtfUJgMRMA==",
             "requires": {
-                "@babel/runtime": "^7.7.2",
-                "@jimp/bmp": "^0.16.1",
-                "@jimp/gif": "^0.16.1",
-                "@jimp/jpeg": "^0.16.1",
-                "@jimp/png": "^0.16.1",
-                "@jimp/tiff": "^0.16.1",
+                "@jimp/bmp": "^0.22.12",
+                "@jimp/gif": "^0.22.12",
+                "@jimp/jpeg": "^0.22.12",
+                "@jimp/png": "^0.22.12",
+                "@jimp/tiff": "^0.22.12",
                 "timm": "^1.6.1"
             }
         },
         "@jimp/utils": {
-            "version": "0.16.1",
-            "resolved": "https://registry.npmjs.org/@jimp/utils/-/utils-0.16.1.tgz",
-            "integrity": "sha512-8fULQjB0x4LzUSiSYG6ZtQl355sZjxbv8r9PPAuYHzS9sGiSHJQavNqK/nKnpDsVkU88/vRGcE7t3nMU0dEnVw==",
+            "version": "0.22.12",
+            "resolved": "https://registry.npmjs.org/@jimp/utils/-/utils-0.22.12.tgz",
+            "integrity": "sha512-yJ5cWUknGnilBq97ZXOyOS0HhsHOyAyjHwYfHxGbSyMTohgQI6sVyE8KPgDwH8HHW/nMKXk8TrSwAE71zt716Q==",
             "requires": {
-                "@babel/runtime": "^7.7.2",
                 "regenerator-runtime": "^0.13.3"
             }
         },
@@ -2037,6 +3243,16 @@
                 "@jridgewell/sourcemap-codec": "^1.4.10"
             }
         },
+        "@socket.io/component-emitter": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
+            "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA=="
+        },
+        "@tokenizer/token": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+            "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="
+        },
         "@tsconfig/node10": {
             "version": "1.0.9",
             "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
@@ -2061,25 +3277,21 @@
             "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
             "dev": true
         },
-        "@types/component-emitter": {
-            "version": "1.2.11",
-            "resolved": "https://registry.npmjs.org/@types/component-emitter/-/component-emitter-1.2.11.tgz",
-            "integrity": "sha512-SRXjM+tfsSlA9VuG8hGO2nft2p8zjXCK1VcC6N4NXbBbYbSia9kzCChYQajIjzIqOOOuh5Ock6MmV2oux4jDZQ=="
-        },
-        "@types/cookie": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
-            "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q=="
-        },
         "@types/cors": {
-            "version": "2.8.12",
-            "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.12.tgz",
-            "integrity": "sha512-vt+kDhq/M2ayberEtJcIN/hxXy1Pk+59g2FV/ZQceeaTyCtCucjL2Q7FXlFjtWn4n15KCr1NE2lNNFhp0lEThw=="
+            "version": "2.8.19",
+            "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+            "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
+            "requires": {
+                "@types/node": "*"
+            }
         },
         "@types/node": {
-            "version": "17.0.33",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.33.tgz",
-            "integrity": "sha512-miWq2m2FiQZmaHfdZNcbpp9PuXg34W5JZ5CrJ/BaS70VuhoJENBEQybeiYSaPBRNq6KQGnjfEnc/F3PN++D+XQ=="
+            "version": "18.19.130",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+            "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+            "requires": {
+                "undici-types": "~5.26.4"
+            }
         },
         "@types/spotify-api": {
             "version": "0.0.16",
@@ -2097,109 +3309,130 @@
             }
         },
         "@vibrant/color": {
-            "version": "3.2.1-alpha.1",
-            "resolved": "https://registry.npmjs.org/@vibrant/color/-/color-3.2.1-alpha.1.tgz",
-            "integrity": "sha512-cvm+jAPwao2NerTr3d1JttYyLhp3eD/AQBeevxF7KT6HctToWZCwr2AeTr003/wKgbjzdOV1qySnbyOeu+R+Jw=="
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/@vibrant/color/-/color-4.0.4.tgz",
+            "integrity": "sha512-Fq2tAszz4QOPWfHZ+KuEAchXUD8i594BM2fOJt8dI/fvYbiVoBycBF/BlNH6F4IWBubxXoPqD4JmmAHvFYbNew=="
         },
         "@vibrant/core": {
-            "version": "3.2.1-alpha.1",
-            "resolved": "https://registry.npmjs.org/@vibrant/core/-/core-3.2.1-alpha.1.tgz",
-            "integrity": "sha512-X9Oa9WfPEQnZ6L+5dLRlh+IlsxJkYTw9b/g3stFKoNXbVRKCeXHmH48l7jIBBOg3VcXOGUdsYBqsTwPNkIveaA==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/@vibrant/core/-/core-4.0.4.tgz",
+            "integrity": "sha512-yZ0XSpW2biKyaJPpBC31AVYgn7NseKSO2q3KNMmDrkL2qC6TEWsBMnSQ28n0m///chZELXpQLx1CCOsWg5pj8w==",
             "requires": {
-                "@vibrant/color": "^3.2.1-alpha.1",
-                "@vibrant/generator": "^3.2.1-alpha.1",
-                "@vibrant/image": "^3.2.1-alpha.1",
-                "@vibrant/quantizer": "^3.2.1-alpha.1",
-                "@vibrant/types": "^3.2.1-alpha.1",
-                "@vibrant/worker": "^3.2.1-alpha.1"
+                "@vibrant/color": "^4.0.4",
+                "@vibrant/generator": "^4.0.4",
+                "@vibrant/image": "^4.0.4",
+                "@vibrant/quantizer": "^4.0.4",
+                "@vibrant/worker": "^4.0.4"
             }
         },
         "@vibrant/generator": {
-            "version": "3.2.1-alpha.1",
-            "resolved": "https://registry.npmjs.org/@vibrant/generator/-/generator-3.2.1-alpha.1.tgz",
-            "integrity": "sha512-luS5YvMhwMqG01YTj1dJ+cmkuIw1VCByOR6zIaCOwQqI/mcOs88JBWcA1r2TywJTOPlVpjfnDvAlyaKBKh4dMA==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/@vibrant/generator/-/generator-4.0.4.tgz",
+            "integrity": "sha512-rwq8PnlpKdch4YqaA1FAwdm71gKE2cMrUsbu72TqRFGa8rpP1roaZlQCVXIIwElXVc3r9axZyAcqyTLaMjhrTg==",
             "requires": {
-                "@vibrant/color": "^3.2.1-alpha.1",
-                "@vibrant/types": "^3.2.1-alpha.1"
+                "@vibrant/color": "^4.0.4",
+                "@vibrant/types": "^4.0.4"
             }
         },
         "@vibrant/generator-default": {
-            "version": "3.2.1-alpha.1",
-            "resolved": "https://registry.npmjs.org/@vibrant/generator-default/-/generator-default-3.2.1-alpha.1.tgz",
-            "integrity": "sha512-BWnQhDaz92UhyHnpdAzKXHQecY+jvyMXtzjKYbveFxThm6+HVoLjwONlbck7oyOpFzV2OM7V11XuR85BxaHvjw==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/@vibrant/generator-default/-/generator-default-4.0.4.tgz",
+            "integrity": "sha512-QeVDeH2dz9lityvJCb84Ml4hlBTElwCpU7SVpiDFBh6gPoCLnzcb1H9G4NgG3hOlAPyrBM+Ivq1Pg+1lZj5Ywg==",
             "requires": {
-                "@vibrant/color": "^3.2.1-alpha.1",
-                "@vibrant/generator": "^3.2.1-alpha.1"
+                "@vibrant/color": "^4.0.4",
+                "@vibrant/generator": "^4.0.4"
             }
         },
         "@vibrant/image": {
-            "version": "3.2.1-alpha.1",
-            "resolved": "https://registry.npmjs.org/@vibrant/image/-/image-3.2.1-alpha.1.tgz",
-            "integrity": "sha512-4aF5k79QfyhZOqRovJpbnIjWfe3uuWhY8voqVdd4/qgu4o70/AwVlM+pYmCaJVzI45VWNWWHYA5QlYuKsXnBqQ==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/@vibrant/image/-/image-4.0.4.tgz",
+            "integrity": "sha512-NBIJj7umfDRVpFjJHQo1AFSCWCzQyjfil+Yxu7W62PEL72GPCif0CDiglPkvVF8QhDLmnx/x1k3LIBb9jWF2sw==",
             "requires": {
-                "@vibrant/color": "^3.2.1-alpha.1",
-                "@vibrant/types": "^3.2.1-alpha.1"
+                "@vibrant/color": "^4.0.4"
             }
         },
         "@vibrant/image-browser": {
-            "version": "3.2.1-alpha.1",
-            "resolved": "https://registry.npmjs.org/@vibrant/image-browser/-/image-browser-3.2.1-alpha.1.tgz",
-            "integrity": "sha512-6xWvQfB20sE6YtCWylgEAHuee3iD8h3aFIDbCS2yj7jIelKcYTrrp5jg2d2BhOOB6pC5JzF+QfpCrm0DmAIlgQ==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/@vibrant/image-browser/-/image-browser-4.0.4.tgz",
+            "integrity": "sha512-7qVyAm+z9t98iwMDzUgGCwgRg0KBB5RXQFgiO2Um5Izd1wO7BKC0SHVEz2k7sRx3XNfBf+JExp8quPrvSz17gg==",
             "requires": {
-                "@vibrant/image": "^3.2.1-alpha.1"
+                "@vibrant/image": "^4.0.4"
             }
         },
         "@vibrant/image-node": {
-            "version": "3.2.1-alpha.1",
-            "resolved": "https://registry.npmjs.org/@vibrant/image-node/-/image-node-3.2.1-alpha.1.tgz",
-            "integrity": "sha512-/Io/Rpo4EkO6AhaXdcxUXkbOFhSFtjm0LSAM4c0AyGA5EbC8PyZqjk8b11bQAEMCaYaweFQfTdGD7oVbXe21CQ==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/@vibrant/image-node/-/image-node-4.0.4.tgz",
+            "integrity": "sha512-aG8Ukt9oTa6FWaAV5oBKsBetkKASWH31hZiFJ2R1291f3TZlphUyQTJz5TubucIRsCEl4dgG1xyxFPgse2IABA==",
             "requires": {
-                "@jimp/custom": "^0.16.1",
-                "@jimp/plugin-resize": "^0.16.1",
-                "@jimp/types": "^0.16.1",
-                "@vibrant/image": "^3.2.1-alpha.1"
+                "@jimp/custom": "^0.22.12",
+                "@jimp/plugin-resize": "^0.22.12",
+                "@jimp/types": "^0.22.12",
+                "@vibrant/image": "^4.0.4"
             }
         },
         "@vibrant/quantizer": {
-            "version": "3.2.1-alpha.1",
-            "resolved": "https://registry.npmjs.org/@vibrant/quantizer/-/quantizer-3.2.1-alpha.1.tgz",
-            "integrity": "sha512-iHnPx/+n4iLtYLm1GClSfyg2fFbMatFG0ipCyp9M6tXNIPAg+pSvUJSGBnVnH7Nl/bR8Gkkj1h0pJ4RsKcdIrQ==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/@vibrant/quantizer/-/quantizer-4.0.4.tgz",
+            "integrity": "sha512-722CooC2W4mlBiv+zyAsIrIvARnMCN/P2Muo8bnWd0SQlVWFtQnFxJWGOUPOPS4DGe3pGoqmNfvS0let4dICZQ==",
             "requires": {
-                "@vibrant/color": "^3.2.1-alpha.1",
-                "@vibrant/image": "^3.2.1-alpha.1",
-                "@vibrant/types": "^3.2.1-alpha.1"
+                "@vibrant/color": "^4.0.4",
+                "@vibrant/image": "^4.0.4",
+                "@vibrant/types": "^4.0.4"
             }
         },
         "@vibrant/quantizer-mmcq": {
-            "version": "3.2.1-alpha.1",
-            "resolved": "https://registry.npmjs.org/@vibrant/quantizer-mmcq/-/quantizer-mmcq-3.2.1-alpha.1.tgz",
-            "integrity": "sha512-Wuk9PTZtxr8qsWTcgP6lcrrmrq36syVwxf+BUxdgQYntBcQ053SaN34lVGOJ0WPdK5vABoxbYljhceCgiILtZw==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/@vibrant/quantizer-mmcq/-/quantizer-mmcq-4.0.4.tgz",
+            "integrity": "sha512-/1CNnM96J8K+OBCWNUzywo6VdnmdFJyiKO+ty/nkfe8H0NseOEHIL7PrVtWGgtsb0rh2uTAq2rjXv65TfgPy8g==",
             "requires": {
-                "@vibrant/color": "^3.2.1-alpha.1",
-                "@vibrant/image": "^3.2.1-alpha.1",
-                "@vibrant/quantizer": "^3.2.1-alpha.1"
+                "@vibrant/color": "^4.0.4",
+                "@vibrant/image": "^4.0.4",
+                "@vibrant/quantizer": "^4.0.4"
             }
         },
         "@vibrant/types": {
-            "version": "3.2.1-alpha.1",
-            "resolved": "https://registry.npmjs.org/@vibrant/types/-/types-3.2.1-alpha.1.tgz",
-            "integrity": "sha512-ts9u7nsrENoYI5s0MmPOeY5kCLFKvQndKVDOPFCbTA0z493uhDp8mpiQhjFYTf3kPbS04z9zbHLE2luFC7x4KQ=="
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/@vibrant/types/-/types-4.0.4.tgz",
+            "integrity": "sha512-Qq3mVTJamn7yD4OBgBEUKaxfDlm3sxBK55N7dH3XzI9Ey7KR00R06uwtqOcEJMsziWTEXdYN3VUlYaj2Tkt7hw=="
         },
         "@vibrant/worker": {
-            "version": "3.2.1-alpha.1",
-            "resolved": "https://registry.npmjs.org/@vibrant/worker/-/worker-3.2.1-alpha.1.tgz",
-            "integrity": "sha512-mtSlBdHkFNr4FOnMtqtHJxy9z5AsUcZzGlpiHzvWOoaoN9lNTDPwxOBd0q4VTYWuGPrIm6Fuq5m7aRbLv7KqiQ==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/@vibrant/worker/-/worker-4.0.4.tgz",
+            "integrity": "sha512-Q/R6PYhSMWCXEk/IcXbWIzIu7Z4b58ABkGvcdF8Y+q/7g+KnpxKW5x/jfQ/6ciyYSby13wZZoEdNr3QQVgsdBQ==",
             "requires": {
-                "@vibrant/types": "^3.2.1-alpha.1"
+                "@vibrant/types": "^4.0.4"
+            }
+        },
+        "abort-controller": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+            "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+            "requires": {
+                "event-target-shim": "^5.0.0"
             }
         },
         "accepts": {
-            "version": "1.3.8",
-            "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
-            "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+            "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
             "requires": {
-                "mime-types": "~2.1.34",
-                "negotiator": "0.6.3"
+                "mime-types": "^3.0.0",
+                "negotiator": "^1.0.0"
+            },
+            "dependencies": {
+                "mime-db": {
+                    "version": "1.54.0",
+                    "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+                    "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="
+                },
+                "mime-types": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+                    "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+                    "requires": {
+                        "mime-db": "^1.54.0"
+                    }
+                }
             }
         },
         "acorn": {
@@ -2225,32 +3458,30 @@
             "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
             "dev": true
         },
-        "array-flatten": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-            "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
-        },
         "asynckit": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
             "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
         },
         "axios": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-            "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+            "version": "1.13.6",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
+            "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
             "requires": {
-                "follow-redirects": "^1.14.9",
-                "form-data": "^4.0.0"
+                "follow-redirects": "^1.15.11",
+                "form-data": "^4.0.5",
+                "proxy-from-env": "^1.1.0"
             },
             "dependencies": {
                 "form-data": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-                    "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+                    "version": "4.0.5",
+                    "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+                    "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
                     "requires": {
                         "asynckit": "^0.4.0",
                         "combined-stream": "^1.0.8",
+                        "es-set-tostringtag": "^2.1.0",
+                        "hasown": "^2.0.2",
                         "mime-types": "^2.1.12"
                     }
                 }
@@ -2272,22 +3503,19 @@
             "integrity": "sha512-vHdS19CnY3hwiNdkaqk93DvjVLfbEcI8mys4UjuWrlX1haDmroo8o4xCzh4wD6DGV6HxRCyauwhHRqMTfERtjw=="
         },
         "body-parser": {
-            "version": "1.20.0",
-            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.0.tgz",
-            "integrity": "sha512-DfJ+q6EPcGKZD1QWUjSpqp+Q7bDQTsQIF4zfUAtZ6qk+H/3/QRhg9CEp39ss+/T2vw0+HaidC0ecJj/DRLIaKg==",
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+            "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
             "requires": {
-                "bytes": "3.1.2",
-                "content-type": "~1.0.4",
-                "debug": "2.6.9",
-                "depd": "2.0.0",
-                "destroy": "1.2.0",
-                "http-errors": "2.0.0",
-                "iconv-lite": "0.4.24",
-                "on-finished": "2.4.1",
-                "qs": "6.10.3",
-                "raw-body": "2.5.1",
-                "type-is": "~1.6.18",
-                "unpipe": "1.0.0"
+                "bytes": "^3.1.2",
+                "content-type": "^1.0.5",
+                "debug": "^4.4.3",
+                "http-errors": "^2.0.0",
+                "iconv-lite": "^0.7.0",
+                "on-finished": "^2.4.1",
+                "qs": "^6.14.1",
+                "raw-body": "^3.0.1",
+                "type-is": "^2.0.1"
             }
         },
         "buffer": {
@@ -2299,23 +3527,27 @@
                 "ieee754": "^1.1.13"
             }
         },
-        "buffer-equal": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz",
-            "integrity": "sha512-RgSV6InVQ9ODPdLWJ5UAqBqJBOg370Nz6ZQtRzpt6nUjc8v0St97uJ4PYC6NztqIScrAXafKM3mZPMygSe1ggA=="
-        },
         "bytes": {
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
             "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="
         },
-        "call-bind": {
+        "call-bind-apply-helpers": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-            "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+            "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+            "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
             "requires": {
-                "function-bind": "^1.1.1",
-                "get-intrinsic": "^1.0.2"
+                "es-errors": "^1.3.0",
+                "function-bind": "^1.1.2"
+            }
+        },
+        "call-bound": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+            "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+            "requires": {
+                "call-bind-apply-helpers": "^1.0.2",
+                "get-intrinsic": "^1.3.0"
             }
         },
         "combined-stream": {
@@ -2332,27 +3564,24 @@
             "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
         },
         "content-disposition": {
-            "version": "0.5.4",
-            "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
-            "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
-            "requires": {
-                "safe-buffer": "5.2.1"
-            }
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+            "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q=="
         },
         "content-type": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-            "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+            "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="
         },
         "cookie": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-            "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw=="
+            "version": "0.7.2",
+            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+            "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="
         },
         "cookie-signature": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-            "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+            "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="
         },
         "cookiejar": {
             "version": "2.1.3",
@@ -2360,9 +3589,9 @@
             "integrity": "sha512-JxbCBUdrfr6AQjOXrxoTvAMJO4HBTUIlBzslcJPAz+/KT8yk53fXun51u+RenNYvad/+Vc2DIz5o9UxlCDymFQ=="
         },
         "cors": {
-            "version": "2.8.5",
-            "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
-            "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+            "version": "2.8.6",
+            "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+            "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
             "requires": {
                 "object-assign": "^4",
                 "vary": "^1"
@@ -2380,11 +3609,11 @@
             "integrity": "sha512-SxQYDD2ZvlsUg7iAQZ8rd/wQc4m+i+uL0087DhyhpF4hTw+fShslpSnldv4PV9QiOhdDqz2vt6pYVoAAheWOsQ=="
         },
         "debug": {
-            "version": "2.6.9",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
             "requires": {
-                "ms": "2.0.0"
+                "ms": "^2.1.3"
             }
         },
         "delayed-stream": {
@@ -2397,130 +3626,210 @@
             "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
             "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
         },
-        "destroy": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
-            "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg=="
-        },
         "diff": {
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
             "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
             "dev": true
         },
-        "dom-walk": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
-            "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="
-        },
         "dotenv": {
             "version": "16.0.1",
             "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.1.tgz",
             "integrity": "sha512-1K6hR6wtk2FviQ4kEiSjFiH5rpzEVi8WW0x96aztHVMhEspNpc4DVOUTEHtEva5VThQ8IaBX1Pe4gSzpVVUsKQ=="
         },
+        "dunder-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+            "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+            "requires": {
+                "call-bind-apply-helpers": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "gopd": "^1.2.0"
+            }
+        },
         "ee-first": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-            "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+            "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
         },
         "encodeurl": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-            "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+            "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="
         },
         "engine.io": {
-            "version": "6.2.0",
-            "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.2.0.tgz",
-            "integrity": "sha512-4KzwW3F3bk+KlzSOY57fj/Jx6LyRQ1nbcyIadehl+AnXjKT7gDO0ORdRi/84ixvMKTym6ZKuxvbzN62HDDU1Lg==",
+            "version": "6.6.5",
+            "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.5.tgz",
+            "integrity": "sha512-2RZdgEbXmp5+dVbRm0P7HQUImZpICccJy7rN7Tv+SFa55pH+lxnuw6/K1ZxxBfHoYpSkHLAO92oa8O4SwFXA2A==",
             "requires": {
-                "@types/cookie": "^0.4.1",
                 "@types/cors": "^2.8.12",
                 "@types/node": ">=10.0.0",
                 "accepts": "~1.3.4",
                 "base64id": "2.0.0",
-                "cookie": "~0.4.1",
+                "cookie": "~0.7.2",
                 "cors": "~2.8.5",
-                "debug": "~4.3.1",
-                "engine.io-parser": "~5.0.3",
-                "ws": "~8.2.3"
+                "debug": "~4.4.1",
+                "engine.io-parser": "~5.2.1",
+                "ws": "~8.18.3"
             },
             "dependencies": {
-                "cookie": {
-                    "version": "0.4.2",
-                    "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
-                    "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA=="
-                },
-                "debug": {
-                    "version": "4.3.4",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-                    "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+                "accepts": {
+                    "version": "1.3.8",
+                    "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+                    "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
                     "requires": {
-                        "ms": "2.1.2"
+                        "mime-types": "~2.1.34",
+                        "negotiator": "0.6.3"
                     }
                 },
-                "ms": {
-                    "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+                "negotiator": {
+                    "version": "0.6.3",
+                    "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+                    "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="
                 }
             }
         },
         "engine.io-parser": {
-            "version": "5.0.4",
-            "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.0.4.tgz",
-            "integrity": "sha512-+nVFp+5z1E3HcToEnO7ZIj3g+3k9389DvWtvJZz0T6/eOCPIyyxehFcedoYrZQrp0LgQbD9pPXhpMBKMd5QURg=="
+            "version": "5.2.3",
+            "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
+            "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q=="
+        },
+        "es-define-property": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+            "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="
+        },
+        "es-errors": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+            "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="
+        },
+        "es-object-atoms": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+            "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+            "requires": {
+                "es-errors": "^1.3.0"
+            }
+        },
+        "es-set-tostringtag": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+            "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+            "requires": {
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.6",
+                "has-tostringtag": "^1.0.2",
+                "hasown": "^2.0.2"
+            }
+        },
+        "esbuild": {
+            "version": "0.27.3",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+            "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+            "dev": true,
+            "requires": {
+                "@esbuild/aix-ppc64": "0.27.3",
+                "@esbuild/android-arm": "0.27.3",
+                "@esbuild/android-arm64": "0.27.3",
+                "@esbuild/android-x64": "0.27.3",
+                "@esbuild/darwin-arm64": "0.27.3",
+                "@esbuild/darwin-x64": "0.27.3",
+                "@esbuild/freebsd-arm64": "0.27.3",
+                "@esbuild/freebsd-x64": "0.27.3",
+                "@esbuild/linux-arm": "0.27.3",
+                "@esbuild/linux-arm64": "0.27.3",
+                "@esbuild/linux-ia32": "0.27.3",
+                "@esbuild/linux-loong64": "0.27.3",
+                "@esbuild/linux-mips64el": "0.27.3",
+                "@esbuild/linux-ppc64": "0.27.3",
+                "@esbuild/linux-riscv64": "0.27.3",
+                "@esbuild/linux-s390x": "0.27.3",
+                "@esbuild/linux-x64": "0.27.3",
+                "@esbuild/netbsd-arm64": "0.27.3",
+                "@esbuild/netbsd-x64": "0.27.3",
+                "@esbuild/openbsd-arm64": "0.27.3",
+                "@esbuild/openbsd-x64": "0.27.3",
+                "@esbuild/openharmony-arm64": "0.27.3",
+                "@esbuild/sunos-x64": "0.27.3",
+                "@esbuild/win32-arm64": "0.27.3",
+                "@esbuild/win32-ia32": "0.27.3",
+                "@esbuild/win32-x64": "0.27.3"
+            }
         },
         "escape-html": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-            "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+            "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
         },
         "etag": {
             "version": "1.8.1",
             "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-            "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
+            "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="
+        },
+        "event-target-shim": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+            "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
+        },
+        "events": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+            "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
         },
         "exif-parser": {
             "version": "0.1.12",
             "resolved": "https://registry.npmjs.org/exif-parser/-/exif-parser-0.1.12.tgz",
-            "integrity": "sha1-WKnS1ywCwfbwKg70qRZicrd2CSI="
+            "integrity": "sha512-c2bQfLNbMzLPmzQuOr8fy0csy84WmwnER81W88DzTp9CYNPJ6yzOj2EZAh9pywYpqHnshVLHQJ8WzldAyfY+Iw=="
         },
         "express": {
-            "version": "4.18.1",
-            "resolved": "https://registry.npmjs.org/express/-/express-4.18.1.tgz",
-            "integrity": "sha512-zZBcOX9TfehHQhtupq57OF8lFZ3UZi08Y97dwFCkD8p9d/d2Y3M+ykKcwaMDEL+4qyUolgBDX6AblpR3fL212Q==",
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+            "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
             "requires": {
-                "accepts": "~1.3.8",
-                "array-flatten": "1.1.1",
-                "body-parser": "1.20.0",
-                "content-disposition": "0.5.4",
-                "content-type": "~1.0.4",
-                "cookie": "0.5.0",
-                "cookie-signature": "1.0.6",
-                "debug": "2.6.9",
-                "depd": "2.0.0",
-                "encodeurl": "~1.0.2",
-                "escape-html": "~1.0.3",
-                "etag": "~1.8.1",
-                "finalhandler": "1.2.0",
-                "fresh": "0.5.2",
-                "http-errors": "2.0.0",
-                "merge-descriptors": "1.0.1",
-                "methods": "~1.1.2",
-                "on-finished": "2.4.1",
-                "parseurl": "~1.3.3",
-                "path-to-regexp": "0.1.7",
-                "proxy-addr": "~2.0.7",
-                "qs": "6.10.3",
-                "range-parser": "~1.2.1",
-                "safe-buffer": "5.2.1",
-                "send": "0.18.0",
-                "serve-static": "1.15.0",
-                "setprototypeof": "1.2.0",
-                "statuses": "2.0.1",
-                "type-is": "~1.6.18",
-                "utils-merge": "1.0.1",
-                "vary": "~1.1.2"
+                "accepts": "^2.0.0",
+                "body-parser": "^2.2.1",
+                "content-disposition": "^1.0.0",
+                "content-type": "^1.0.5",
+                "cookie": "^0.7.1",
+                "cookie-signature": "^1.2.1",
+                "debug": "^4.4.0",
+                "depd": "^2.0.0",
+                "encodeurl": "^2.0.0",
+                "escape-html": "^1.0.3",
+                "etag": "^1.8.1",
+                "finalhandler": "^2.1.0",
+                "fresh": "^2.0.0",
+                "http-errors": "^2.0.0",
+                "merge-descriptors": "^2.0.0",
+                "mime-types": "^3.0.0",
+                "on-finished": "^2.4.1",
+                "once": "^1.4.0",
+                "parseurl": "^1.3.3",
+                "proxy-addr": "^2.0.7",
+                "qs": "^6.14.0",
+                "range-parser": "^1.2.1",
+                "router": "^2.2.0",
+                "send": "^1.1.0",
+                "serve-static": "^2.2.0",
+                "statuses": "^2.0.1",
+                "type-is": "^2.0.1",
+                "vary": "^1.1.2"
+            },
+            "dependencies": {
+                "mime-db": {
+                    "version": "1.54.0",
+                    "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+                    "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="
+                },
+                "mime-types": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+                    "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+                    "requires": {
+                        "mime-db": "^1.54.0"
+                    }
+                }
             }
         },
         "fast-safe-stringify": {
@@ -2529,28 +3838,32 @@
             "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
         },
         "file-type": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/file-type/-/file-type-9.0.0.tgz",
-            "integrity": "sha512-Qe/5NJrgIOlwijpq3B7BEpzPFcgzggOTagZmkXQY4LA6bsXKTUstK7Wp12lEJ/mLKTpvIZxmIuRcLYWT6ov9lw=="
+            "version": "16.5.4",
+            "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
+            "integrity": "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==",
+            "requires": {
+                "readable-web-to-node-stream": "^3.0.0",
+                "strtok3": "^6.2.4",
+                "token-types": "^4.1.1"
+            }
         },
         "finalhandler": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
-            "integrity": "sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+            "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
             "requires": {
-                "debug": "2.6.9",
-                "encodeurl": "~1.0.2",
-                "escape-html": "~1.0.3",
-                "on-finished": "2.4.1",
-                "parseurl": "~1.3.3",
-                "statuses": "2.0.1",
-                "unpipe": "~1.0.0"
+                "debug": "^4.4.0",
+                "encodeurl": "^2.0.0",
+                "escape-html": "^1.0.3",
+                "on-finished": "^2.4.1",
+                "parseurl": "^1.3.3",
+                "statuses": "^2.0.1"
             }
         },
         "follow-redirects": {
-            "version": "1.15.1",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
-            "integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA=="
+            "version": "1.15.11",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+            "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ=="
         },
         "form-data": {
             "version": "3.0.1",
@@ -2573,74 +3886,110 @@
             "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="
         },
         "fresh": {
-            "version": "0.5.2",
-            "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-            "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+            "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="
+        },
+        "fsevents": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+            "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+            "dev": true,
+            "optional": true
         },
         "function-bind": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+            "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
         },
         "get-intrinsic": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
-            "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+            "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
             "requires": {
-                "function-bind": "^1.1.1",
-                "has": "^1.0.3",
-                "has-symbols": "^1.0.1"
+                "call-bind-apply-helpers": "^1.0.2",
+                "es-define-property": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "es-object-atoms": "^1.1.1",
+                "function-bind": "^1.1.2",
+                "get-proto": "^1.0.1",
+                "gopd": "^1.2.0",
+                "has-symbols": "^1.1.0",
+                "hasown": "^2.0.2",
+                "math-intrinsics": "^1.1.0"
+            }
+        },
+        "get-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+            "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+            "requires": {
+                "dunder-proto": "^1.0.1",
+                "es-object-atoms": "^1.0.0"
+            }
+        },
+        "get-tsconfig": {
+            "version": "4.13.6",
+            "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
+            "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
+            "dev": true,
+            "requires": {
+                "resolve-pkg-maps": "^1.0.0"
             }
         },
         "gifwrap": {
-            "version": "0.9.4",
-            "resolved": "https://registry.npmjs.org/gifwrap/-/gifwrap-0.9.4.tgz",
-            "integrity": "sha512-MDMwbhASQuVeD4JKd1fKgNgCRL3fGqMM4WaqpNhWO0JiMOAjbQdumbs4BbBZEy9/M00EHEjKN3HieVhCUlwjeQ==",
+            "version": "0.10.1",
+            "resolved": "https://registry.npmjs.org/gifwrap/-/gifwrap-0.10.1.tgz",
+            "integrity": "sha512-2760b1vpJHNmLzZ/ubTtNnEx5WApN/PYWJvXvgS+tL1egTTthayFYIQQNi136FLEDcN/IyEY2EcGpIITD6eYUw==",
             "requires": {
                 "image-q": "^4.0.0",
                 "omggif": "^1.0.10"
             }
         },
-        "global": {
-            "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
-            "integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
-            "requires": {
-                "min-document": "^2.19.0",
-                "process": "^0.11.10"
-            }
-        },
-        "has": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-            "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-            "requires": {
-                "function-bind": "^1.1.1"
-            }
+        "gopd": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+            "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="
         },
         "has-symbols": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-            "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+            "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="
+        },
+        "has-tostringtag": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+            "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+            "requires": {
+                "has-symbols": "^1.0.3"
+            }
+        },
+        "hasown": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+            "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+            "requires": {
+                "function-bind": "^1.1.2"
+            }
         },
         "http-errors": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-            "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+            "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
             "requires": {
-                "depd": "2.0.0",
-                "inherits": "2.0.4",
-                "setprototypeof": "1.2.0",
-                "statuses": "2.0.1",
-                "toidentifier": "1.0.1"
+                "depd": "~2.0.0",
+                "inherits": "~2.0.4",
+                "setprototypeof": "~1.2.0",
+                "statuses": "~2.0.2",
+                "toidentifier": "~1.0.1"
             }
         },
         "iconv-lite": {
-            "version": "0.4.24",
-            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-            "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+            "version": "0.7.2",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+            "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
             "requires": {
-                "safer-buffer": ">= 2.1.2 < 3"
+                "safer-buffer": ">= 2.1.2 < 3.0.0"
             }
         },
         "ieee754": {
@@ -2673,30 +4022,24 @@
             "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
             "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
         },
-        "is-function": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.2.tgz",
-            "integrity": "sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ=="
+        "is-promise": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+            "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="
+        },
+        "isomorphic-fetch": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
+            "integrity": "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==",
+            "requires": {
+                "node-fetch": "^2.6.1",
+                "whatwg-fetch": "^3.4.1"
+            }
         },
         "jpeg-js": {
-            "version": "0.4.2",
-            "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.2.tgz",
-            "integrity": "sha512-+az2gi/hvex7eLTMTlbRLOhH6P6WFdk2ITI8HJsaH2VqYO0I594zXSYEP+tf4FW+8Cy68ScDXoAsQdyQanv3sw=="
-        },
-        "load-bmfont": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/load-bmfont/-/load-bmfont-1.4.1.tgz",
-            "integrity": "sha512-8UyQoYmdRDy81Brz6aLAUhfZLwr5zV0L3taTQ4hju7m6biuwiWiJXjPhBJxbUQJA8PrkvJ/7Enqmwk2sM14soA==",
-            "requires": {
-                "buffer-equal": "0.0.1",
-                "mime": "^1.3.4",
-                "parse-bmfont-ascii": "^1.0.3",
-                "parse-bmfont-binary": "^1.0.5",
-                "parse-bmfont-xml": "^1.1.4",
-                "phin": "^2.9.1",
-                "xhr": "^2.0.1",
-                "xtend": "^4.0.0"
-            }
+            "version": "0.4.4",
+            "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.4.tgz",
+            "integrity": "sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg=="
         },
         "lru-cache": {
             "version": "6.0.0",
@@ -2717,25 +4060,25 @@
             "resolved": "https://registry.npmjs.org/marvinj/-/marvinj-1.0.0.tgz",
             "integrity": "sha512-+afDa86Pml2BlDt2lEn+xZUZ6r4q+aQvxSmWq37M4lQ4SraBJcKlbm+wDamzXTvW7OmeK0mkWdjRB4R3PAPFjA=="
         },
+        "math-intrinsics": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+            "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="
+        },
         "media-typer": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-            "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+            "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="
         },
         "merge-descriptors": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-            "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+            "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="
         },
         "methods": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
             "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
-        },
-        "mime": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-            "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
         },
         "mime-db": {
             "version": "1.52.0",
@@ -2750,67 +4093,46 @@
                 "mime-db": "1.52.0"
             }
         },
-        "min-document": {
-            "version": "2.19.0",
-            "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
-            "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
-            "requires": {
-                "dom-walk": "^0.1.0"
-            }
-        },
-        "minimist": {
-            "version": "1.2.6",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-            "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
-        },
-        "mkdirp": {
-            "version": "0.5.6",
-            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-            "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-            "requires": {
-                "minimist": "^1.2.6"
-            }
-        },
         "ms": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
         },
         "negotiator": {
-            "version": "0.6.3",
-            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
-            "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+            "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="
+        },
+        "node-fetch": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+            "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+            "requires": {
+                "whatwg-url": "^5.0.0"
+            }
         },
         "node-vibrant": {
-            "version": "3.2.1-alpha.1",
-            "resolved": "https://registry.npmjs.org/node-vibrant/-/node-vibrant-3.2.1-alpha.1.tgz",
-            "integrity": "sha512-EQergCp7fvbvUCE0VMCBnvaAV0lGWSP8SXLmuWQIBzQK5M5pIwcd9fIOXuzFkJx/8hUiiiLvAzzGDS/bIy2ikA==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/node-vibrant/-/node-vibrant-4.0.4.tgz",
+            "integrity": "sha512-hA/pUXBE9TJ41G9FlTkzeqD5JdxgvvPGYZb/HNpdkaxxXUEnP36imSolZ644JuPun+lTd+FpWWtBpTYdp2noQA==",
             "requires": {
-                "@types/node": "^10.12.18",
-                "@vibrant/core": "^3.2.1-alpha.1",
-                "@vibrant/generator-default": "^3.2.1-alpha.1",
-                "@vibrant/image-browser": "^3.2.1-alpha.1",
-                "@vibrant/image-node": "^3.2.1-alpha.1",
-                "@vibrant/quantizer-mmcq": "^3.2.1-alpha.1",
-                "url": "^0.11.0"
-            },
-            "dependencies": {
-                "@types/node": {
-                    "version": "10.17.60",
-                    "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
-                    "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
-                }
+                "@types/node": "^18.15.3",
+                "@vibrant/core": "^4.0.4",
+                "@vibrant/generator-default": "^4.0.4",
+                "@vibrant/image-browser": "^4.0.4",
+                "@vibrant/image-node": "^4.0.4",
+                "@vibrant/quantizer-mmcq": "^4.0.4"
             }
         },
         "object-assign": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+            "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
         },
         "object-inspect": {
-            "version": "1.12.0",
-            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
-            "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g=="
+            "version": "1.13.4",
+            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+            "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="
         },
         "omggif": {
             "version": "1.0.10",
@@ -2825,34 +4147,18 @@
                 "ee-first": "1.1.1"
             }
         },
+        "once": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+            "requires": {
+                "wrappy": "1"
+            }
+        },
         "pako": {
             "version": "1.0.11",
             "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
             "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
-        },
-        "parse-bmfont-ascii": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/parse-bmfont-ascii/-/parse-bmfont-ascii-1.0.6.tgz",
-            "integrity": "sha1-Eaw8P/WPfCAgqyJ2kHkQjU36AoU="
-        },
-        "parse-bmfont-binary": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/parse-bmfont-binary/-/parse-bmfont-binary-1.0.6.tgz",
-            "integrity": "sha1-0Di0dtPp3Z2x4RoLDlOiJ5K2kAY="
-        },
-        "parse-bmfont-xml": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/parse-bmfont-xml/-/parse-bmfont-xml-1.1.4.tgz",
-            "integrity": "sha512-bjnliEOmGv3y1aMEfREMBJ9tfL3WR0i0CKPj61DnSLaoxWR3nLrsQrEbCId/8rF4NyRF0cCqisSVXyQYWM+mCQ==",
-            "requires": {
-                "xml-parse-from-string": "^1.0.0",
-                "xml2js": "^0.4.5"
-            }
-        },
-        "parse-headers": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.5.tgz",
-            "integrity": "sha512-ft3iAoLOB/MlwbNXgzy43SWGP6sQki2jQvAyBg/zDFAgr9bfNWZIUj42Kw2eJIl8kEi4PbgE6U1Zau/HwI75HA=="
         },
         "parseurl": {
             "version": "1.3.3",
@@ -2860,27 +4166,34 @@
             "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
         },
         "path-to-regexp": {
-            "version": "0.1.7",
-            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-            "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+            "version": "8.3.0",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+            "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA=="
         },
-        "phin": {
-            "version": "2.9.3",
-            "resolved": "https://registry.npmjs.org/phin/-/phin-2.9.3.tgz",
-            "integrity": "sha512-CzFr90qM24ju5f88quFC/6qohjC144rehe5n6DH900lgXmUe86+xCKc10ev56gRKC4/BkHUoG4uSiQgBiIXwDA=="
+        "peek-readable": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-4.1.0.tgz",
+            "integrity": "sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg=="
         },
         "pixelmatch": {
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-4.0.2.tgz",
-            "integrity": "sha1-j0fc7FARtHe2fbA8JDvB8wheiFQ=",
+            "integrity": "sha512-J8B6xqiO37sU/gkcMglv6h5Jbd9xNER7aHzpfRdNmV4IbQBzBpe4l9XmbG+xPF/znacgu2jfEw+wHffaq/YkXA==",
             "requires": {
                 "pngjs": "^3.0.0"
+            },
+            "dependencies": {
+                "pngjs": {
+                    "version": "3.4.0",
+                    "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.4.0.tgz",
+                    "integrity": "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w=="
+                }
             }
         },
         "pngjs": {
-            "version": "3.4.0",
-            "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.4.0.tgz",
-            "integrity": "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w=="
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-6.0.0.tgz",
+            "integrity": "sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg=="
         },
         "prettier": {
             "version": "2.6.2",
@@ -2891,7 +4204,7 @@
         "process": {
             "version": "0.11.10",
             "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-            "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
+            "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="
         },
         "proxy-addr": {
             "version": "2.0.7",
@@ -2902,23 +4215,18 @@
                 "ipaddr.js": "1.9.1"
             }
         },
-        "punycode": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-            "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+        "proxy-from-env": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
         },
         "qs": {
-            "version": "6.10.3",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
-            "integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
+            "version": "6.15.0",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+            "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
             "requires": {
-                "side-channel": "^1.0.4"
+                "side-channel": "^1.1.0"
             }
-        },
-        "querystring": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-            "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
         },
         "range-parser": {
             "version": "1.2.1",
@@ -2926,14 +4234,14 @@
             "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
         },
         "raw-body": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
-            "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+            "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
             "requires": {
-                "bytes": "3.1.2",
-                "http-errors": "2.0.0",
-                "iconv-lite": "0.4.24",
-                "unpipe": "1.0.0"
+                "bytes": "~3.1.2",
+                "http-errors": "~2.0.1",
+                "iconv-lite": "~0.7.0",
+                "unpipe": "~1.0.0"
             }
         },
         "readable-stream": {
@@ -2946,10 +4254,59 @@
                 "util-deprecate": "^1.0.1"
             }
         },
+        "readable-web-to-node-stream": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.4.tgz",
+            "integrity": "sha512-9nX56alTf5bwXQ3ZDipHJhusu9NTQJ/CVPtb/XHAJCXihZeitfJvIRS4GqQ/mfIoOE3IelHMrpayVrosdHBuLw==",
+            "requires": {
+                "readable-stream": "^4.7.0"
+            },
+            "dependencies": {
+                "buffer": {
+                    "version": "6.0.3",
+                    "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+                    "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+                    "requires": {
+                        "base64-js": "^1.3.1",
+                        "ieee754": "^1.2.1"
+                    }
+                },
+                "readable-stream": {
+                    "version": "4.7.0",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+                    "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+                    "requires": {
+                        "abort-controller": "^3.0.0",
+                        "buffer": "^6.0.3",
+                        "events": "^3.3.0",
+                        "process": "^0.11.10",
+                        "string_decoder": "^1.3.0"
+                    }
+                }
+            }
+        },
         "regenerator-runtime": {
-            "version": "0.13.9",
-            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-            "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
+            "version": "0.13.11",
+            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+            "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
+        },
+        "resolve-pkg-maps": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+            "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+            "dev": true
+        },
+        "router": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+            "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+            "requires": {
+                "debug": "^4.4.0",
+                "depd": "^2.0.0",
+                "is-promise": "^4.0.0",
+                "parseurl": "^1.3.3",
+                "path-to-regexp": "^8.0.0"
+            }
         },
         "safe-buffer": {
             "version": "5.2.1",
@@ -2975,41 +4332,47 @@
             }
         },
         "send": {
-            "version": "0.18.0",
-            "resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
-            "integrity": "sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+            "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
             "requires": {
-                "debug": "2.6.9",
-                "depd": "2.0.0",
-                "destroy": "1.2.0",
-                "encodeurl": "~1.0.2",
-                "escape-html": "~1.0.3",
-                "etag": "~1.8.1",
-                "fresh": "0.5.2",
-                "http-errors": "2.0.0",
-                "mime": "1.6.0",
-                "ms": "2.1.3",
-                "on-finished": "2.4.1",
-                "range-parser": "~1.2.1",
-                "statuses": "2.0.1"
+                "debug": "^4.4.3",
+                "encodeurl": "^2.0.0",
+                "escape-html": "^1.0.3",
+                "etag": "^1.8.1",
+                "fresh": "^2.0.0",
+                "http-errors": "^2.0.1",
+                "mime-types": "^3.0.2",
+                "ms": "^2.1.3",
+                "on-finished": "^2.4.1",
+                "range-parser": "^1.2.1",
+                "statuses": "^2.0.2"
             },
             "dependencies": {
-                "ms": {
-                    "version": "2.1.3",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-                    "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+                "mime-db": {
+                    "version": "1.54.0",
+                    "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+                    "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="
+                },
+                "mime-types": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+                    "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+                    "requires": {
+                        "mime-db": "^1.54.0"
+                    }
                 }
             }
         },
         "serve-static": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.15.0.tgz",
-            "integrity": "sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==",
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+            "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
             "requires": {
-                "encodeurl": "~1.0.2",
-                "escape-html": "~1.0.3",
-                "parseurl": "~1.3.3",
-                "send": "0.18.0"
+                "encodeurl": "^2.0.0",
+                "escape-html": "^1.0.3",
+                "parseurl": "^1.3.3",
+                "send": "^1.2.0"
             }
         },
         "setprototypeof": {
@@ -3027,71 +4390,95 @@
             }
         },
         "side-channel": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
-            "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+            "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
             "requires": {
-                "call-bind": "^1.0.0",
-                "get-intrinsic": "^1.0.2",
-                "object-inspect": "^1.9.0"
+                "es-errors": "^1.3.0",
+                "object-inspect": "^1.13.3",
+                "side-channel-list": "^1.0.0",
+                "side-channel-map": "^1.0.1",
+                "side-channel-weakmap": "^1.0.2"
+            }
+        },
+        "side-channel-list": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+            "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+            "requires": {
+                "es-errors": "^1.3.0",
+                "object-inspect": "^1.13.3"
+            }
+        },
+        "side-channel-map": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+            "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+            "requires": {
+                "call-bound": "^1.0.2",
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.5",
+                "object-inspect": "^1.13.3"
+            }
+        },
+        "side-channel-weakmap": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+            "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+            "requires": {
+                "call-bound": "^1.0.2",
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.5",
+                "object-inspect": "^1.13.3",
+                "side-channel-map": "^1.0.1"
             }
         },
         "socket.io": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.5.0.tgz",
-            "integrity": "sha512-slTYqU2jCgMjXwresG8grhUi/cC6GjzmcfqArzaH3BN/9I/42eZk9yamNvZJdBfTubkjEdKAKs12NEztId+bUA==",
+            "version": "4.8.3",
+            "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.8.3.tgz",
+            "integrity": "sha512-2Dd78bqzzjE6KPkD5fHZmDAKRNe3J15q+YHDrIsy9WEkqttc7GY+kT9OBLSMaPbQaEd0x1BjcmtMtXkfpc+T5A==",
             "requires": {
                 "accepts": "~1.3.4",
                 "base64id": "~2.0.0",
-                "debug": "~4.3.2",
-                "engine.io": "~6.2.0",
-                "socket.io-adapter": "~2.4.0",
-                "socket.io-parser": "~4.0.4"
+                "cors": "~2.8.5",
+                "debug": "~4.4.1",
+                "engine.io": "~6.6.0",
+                "socket.io-adapter": "~2.5.2",
+                "socket.io-parser": "~4.2.4"
             },
             "dependencies": {
-                "debug": {
-                    "version": "4.3.4",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-                    "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+                "accepts": {
+                    "version": "1.3.8",
+                    "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+                    "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
                     "requires": {
-                        "ms": "2.1.2"
+                        "mime-types": "~2.1.34",
+                        "negotiator": "0.6.3"
                     }
                 },
-                "ms": {
-                    "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+                "negotiator": {
+                    "version": "0.6.3",
+                    "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+                    "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="
                 }
             }
         },
         "socket.io-adapter": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.4.0.tgz",
-            "integrity": "sha512-W4N+o69rkMEGVuk2D/cvca3uYsvGlMwsySWV447y99gUPghxq42BxqLNMndb+a1mm/5/7NeXVQS7RLa2XyXvYg=="
+            "version": "2.5.6",
+            "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.6.tgz",
+            "integrity": "sha512-DkkO/dz7MGln0dHn5bmN3pPy+JmywNICWrJqVWiVOyvXjWQFIv9c2h24JrQLLFJ2aQVQf/Cvl1vblnd4r2apLQ==",
+            "requires": {
+                "debug": "~4.4.1",
+                "ws": "~8.18.3"
+            }
         },
         "socket.io-parser": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.0.4.tgz",
-            "integrity": "sha512-t+b0SS+IxG7Rxzda2EVvyBZbvFPBCjJoyHuE0P//7OAsN23GItzDRdWa6ALxZI/8R5ygK7jAR6t028/z+7295g==",
+            "version": "4.2.5",
+            "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.5.tgz",
+            "integrity": "sha512-bPMmpy/5WWKHea5Y/jYAP6k74A+hvmRCQaJuJB6I/ML5JZq/KfNieUVo/3Mh7SAqn7TyFdIo6wqYHInG1MU1bQ==",
             "requires": {
-                "@types/component-emitter": "^1.2.10",
-                "component-emitter": "~1.3.0",
-                "debug": "~4.3.1"
-            },
-            "dependencies": {
-                "debug": {
-                    "version": "4.3.4",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-                    "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-                    "requires": {
-                        "ms": "2.1.2"
-                    }
-                },
-                "ms": {
-                    "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-                }
+                "@socket.io/component-emitter": "~3.1.0",
+                "debug": "~4.4.1"
             }
         },
         "spotify-web-api-node": {
@@ -3103,9 +4490,9 @@
             }
         },
         "statuses": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-            "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ=="
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+            "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="
         },
         "string_decoder": {
             "version": "1.3.0",
@@ -3113,6 +4500,15 @@
             "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
             "requires": {
                 "safe-buffer": "~5.2.0"
+            }
+        },
+        "strtok3": {
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.3.0.tgz",
+            "integrity": "sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw==",
+            "requires": {
+                "@tokenizer/token": "^0.3.0",
+                "peek-readable": "^4.1.0"
             }
         },
         "superagent": {
@@ -3133,23 +4529,10 @@
                 "semver": "^7.3.2"
             },
             "dependencies": {
-                "debug": {
-                    "version": "4.3.4",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-                    "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-                    "requires": {
-                        "ms": "2.1.2"
-                    }
-                },
                 "mime": {
                     "version": "2.6.0",
                     "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
                     "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg=="
-                },
-                "ms": {
-                    "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
                 }
             }
         },
@@ -3159,19 +4542,33 @@
             "integrity": "sha512-IjZc9KIotudix8bMaBW6QvMuq64BrJWFs1+4V0lXwWGQZwH+LnX87doAYhem4caOEusRP9/g6jVDQmZ8XOk1nw=="
         },
         "tinycolor2": {
-            "version": "1.4.2",
-            "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.2.tgz",
-            "integrity": "sha512-vJhccZPs965sV/L2sU4oRQVAos0pQXwsvTLkWYdqJ+a8Q5kPFzJTuOFwy7UniPli44NKQGAglksjvOcpo95aZA=="
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
+            "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw=="
         },
         "toidentifier": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
             "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="
         },
+        "token-types": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/token-types/-/token-types-4.2.1.tgz",
+            "integrity": "sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ==",
+            "requires": {
+                "@tokenizer/token": "^0.3.0",
+                "ieee754": "^1.2.1"
+            }
+        },
+        "tr46": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+        },
         "ts-node": {
-            "version": "10.8.1",
-            "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.8.1.tgz",
-            "integrity": "sha512-Wwsnao4DQoJsN034wePSg5nZiw4YKXf56mPIAeD6wVmiv+RytNSWqc2f3fKvcUoV+Yn2+yocD71VOfQHbmVX4g==",
+            "version": "10.9.2",
+            "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+            "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
             "dev": true,
             "requires": {
                 "@cspotcode/source-map-support": "^0.8.0",
@@ -3189,13 +4586,40 @@
                 "yn": "3.1.1"
             }
         },
-        "type-is": {
-            "version": "1.6.18",
-            "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
-            "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+        "tsx": {
+            "version": "4.21.0",
+            "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+            "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+            "dev": true,
             "requires": {
-                "media-typer": "0.3.0",
-                "mime-types": "~2.1.24"
+                "esbuild": "~0.27.0",
+                "fsevents": "~2.3.3",
+                "get-tsconfig": "^4.7.5"
+            }
+        },
+        "type-is": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+            "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+            "requires": {
+                "content-type": "^1.0.5",
+                "media-typer": "^1.1.0",
+                "mime-types": "^3.0.0"
+            },
+            "dependencies": {
+                "mime-db": {
+                    "version": "1.54.0",
+                    "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+                    "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="
+                },
+                "mime-types": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+                    "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+                    "requires": {
+                        "mime-db": "^1.54.0"
+                    }
+                }
             }
         },
         "typescript": {
@@ -3204,37 +4628,28 @@
             "integrity": "sha512-WOkT3XYvrpXx4vMMqlD+8R8R37fZkjyLGlxavMc4iB8lrl8L0DeTcHbYgw/v0N/z9wAFsgBhcsF0ruoySS22mA==",
             "dev": true
         },
+        "undici-types": {
+            "version": "5.26.5",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+            "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+        },
         "unpipe": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-            "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+            "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="
         },
-        "url": {
-            "version": "0.11.0",
-            "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
-            "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
+        "utif2": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/utif2/-/utif2-4.1.0.tgz",
+            "integrity": "sha512-+oknB9FHrJ7oW7A2WZYajOcv4FcDR4CfoGB0dPNfxbi4GO05RRnFmt5oa23+9w32EanrYcSJWspUiJkLMs+37w==",
             "requires": {
-                "punycode": "1.3.2",
-                "querystring": "0.2.0"
-            }
-        },
-        "utif": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/utif/-/utif-2.0.1.tgz",
-            "integrity": "sha512-Z/S1fNKCicQTf375lIP9G8Sa1H/phcysstNrrSdZKj1f9g58J4NMgb5IgiEZN9/nLMPDwF0W7hdOe9Qq2IYoLg==",
-            "requires": {
-                "pako": "^1.0.5"
+                "pako": "^1.0.11"
             }
         },
         "util-deprecate": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
             "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
-        },
-        "utils-merge": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-            "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
         },
         "v8-compile-cache-lib": {
             "version": "3.0.1",
@@ -3247,27 +4662,35 @@
             "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
             "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
         },
-        "ws": {
-            "version": "8.2.3",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
-            "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
-            "requires": {}
+        "webidl-conversions": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
         },
-        "xhr": {
-            "version": "2.6.0",
-            "resolved": "https://registry.npmjs.org/xhr/-/xhr-2.6.0.tgz",
-            "integrity": "sha512-/eCGLb5rxjx5e3mF1A7s+pLlR6CGyqWN91fv1JgER5mVWg1MZmlhBvy9kjcsOdRk8RrIujotWyJamfyrp+WIcA==",
+        "whatwg-fetch": {
+            "version": "3.6.20",
+            "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
+            "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg=="
+        },
+        "whatwg-url": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+            "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
             "requires": {
-                "global": "~4.4.0",
-                "is-function": "^1.0.1",
-                "parse-headers": "^2.0.0",
-                "xtend": "^4.0.0"
+                "tr46": "~0.0.3",
+                "webidl-conversions": "^3.0.0"
             }
         },
-        "xml-parse-from-string": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/xml-parse-from-string/-/xml-parse-from-string-1.0.1.tgz",
-            "integrity": "sha1-qQKekp09vN7RafPG4oI42VpdWig="
+        "wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+        },
+        "ws": {
+            "version": "8.18.3",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+            "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+            "requires": {}
         },
         "xml2js": {
             "version": "0.4.23",
@@ -3282,11 +4705,6 @@
             "version": "11.0.1",
             "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
             "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
-        },
-        "xtend": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-            "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
         },
         "yallist": {
             "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
     "name": "shairportgui",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "Web-based GUI server (lol) for shairport-sync",
     "main": "src/index.js",
     "scripts": {
-        "start": "ts-node src/index.js",
+        "start": "tsx src/index.js",
         "test": "echo \"Error: no test specified\" && exit 1"
     },
     "repository": {
@@ -19,19 +19,20 @@
     "homepage": "https://github.com/Rosalina121/ShairportGUI#readme",
     "dependencies": {
         "@check-light-or-dark/image": "^1.0.4",
-        "axios": "^0.27.2",
+        "axios": "^1.13.6",
         "dotenv": "^16.0.1",
-        "express": "^4.18.1",
+        "express": "^5.2.1",
         "marvinj": "^1.0.0",
-        "node-vibrant": "^3.2.1-alpha.1",
+        "node-vibrant": "^4.0.4",
         "shairport-sync-reader": "^0.0.9",
-        "socket.io": "^4.5.0",
+        "socket.io": "^4.8.3",
         "spotify-web-api-node": "^5.0.2"
     },
     "devDependencies": {
         "@types/spotify-web-api-node": "^5.0.7",
         "prettier": "2.6.2",
-        "ts-node": "^10.8.1",
+        "ts-node": "^10.9.2",
+        "tsx": "^4.21.0",
         "typescript": "^4.7.3"
     }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -15,15 +15,17 @@
         <div class="background-img"></div>
         <canvas class="orb-canvas"></canvas>
         <div class="container">
-            <div class="thumbnail-border" onclick="toggleBackgroundType()">
-                <img
-                    id="cover"
-                    src="http://test.palitechnika.com/Transgender_Pride_flag.png"
-                    class="song-thumbnail"
-                />
+            <div class="thumbnail-border" id="thumbnail-container" onclick="toggleBackgroundType()">
+                <div id="spin-container" class="spin-container">
+                    <img
+                        id="cover"
+                        src="http://test.palitechnika.com/Transgender_Pride_flag.png"
+                        class="song-thumbnail"
+                    />
+                </div>
             </div>
             <!--/thumbnail-border -->
-            <div class="song-details">
+            <div class="song-details"> 
                 <span id="title" class="song-title">Song Title</span>
                 <span id="album" class="album-title">Album title</span>
                 <span id="artist" class="artist">Band ft. Song Artist</span>
@@ -31,6 +33,24 @@
             <!-- /song-details -->
         </div>
         <!-- /container -->
+
+        <button id="options-btn" class="options-btn"><i class="fas fa-cog"></i></button>
+        
+        <div id="options-menu" class="options-menu">
+            <h3>Options</h3>
+            <div class="option-item">
+                <label>Cover Spinning</label>
+                <input type="checkbox" id="spin-toggle" checked />
+            </div>
+            <div class="option-item">
+                <label>Cover Shape</label>
+                <select id="shape-select">
+                    <option value="circle">Circle</option>
+                    <option value="rounded-square">Rounded Square</option>
+                </select>
+            </div>
+        </div>
+
         <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/2.3.0/socket.io.js"></script>
         <script type="module" src="fancyBlur.js"></script>
         <script src="scripts.js"></script>

--- a/public/scripts.js
+++ b/public/scripts.js
@@ -5,7 +5,7 @@ const imgContainer = document.querySelector(".background-img");
 
 let internalPalette = {};
 let oldFancyColors = {};
-let isBright = true; // with placeholder image and other placeholder values it does not matter in init
+let isBright = true;
 
 const applyPallette = (palette) => {
     internalPalette = palette;
@@ -24,7 +24,6 @@ const applyPallette = (palette) => {
 };
 
 function getBrightness(imageSrc, callback) {
-    // TODO: use a promise, what year is it?
     const img = document.createElement("img");
     img.src = imageSrc;
     img.crossOrigin = "anonymous";
@@ -81,6 +80,7 @@ const processTypes = (backgroundType) => {
 const onInit = () => {
     backgroundType = getBackgroundType();
     processTypes(backgroundType);
+    initOptions();
 };
 
 const changeStyle = (backgroundTypeVar) => {
@@ -90,7 +90,6 @@ const changeStyle = (backgroundTypeVar) => {
     backgroundType = backgroundTypeVar;
 };
 
-// toggle background styles between image, blur and blurHash
 const toggleBackgroundType = () => {
     const backgroundType = getBackgroundType();
     if (backgroundType === "image") {
@@ -123,8 +122,6 @@ const setBackgroundImage = () => {
 const setBackgroundFancy = () => {
     document.querySelector(".orb-canvas").style.removeProperty("display");
     document.querySelector(".background-img").style.display = "none";
-    // I shouldn't have done that but it works
-    // also, should add handling if fancy has been already set
     import("./fancyBlur.js")
         .then(({ startFancyBlur }) => {
             startFancyBlur();
@@ -150,10 +147,8 @@ const setBackgroundBlur = () => {
       radial-gradient(circle at bottom right,
         rgba(var(--brShadowColorRaw), 1),
         rgba(255, 255, 255, 0) 60%)`;
-    // imgContainer.style.filter = "brightness(0.8)";
 };
 
-// get background type (either image, blur or fancy) from browser local storage
 const getBackgroundType = () => {
     let backgroundType = localStorage.getItem("backgroundType");
     if (backgroundType === null) {
@@ -173,17 +168,12 @@ const updateBackground = (backgroundType, pictureData) => {
             updateBackgroundImage(pictureData);
             break;
         default:
-            // basically blur, do nothing as blur uses palette colors
-            // fancy too
-            // this can be an if statement,
-            // but I'm leaving this in case I want to add more background types
             break;
     }
 };
 
 const updateBackgroundImage = (pictureData) => {
     imgContainer.style.backgroundImage = `url(data:image/png;base64,${pictureData})`;
-    // fot initial load
     if (imgContainer.style.filter === "") {
         imgContainer.style.filter = "blur(70px)";
     }
@@ -209,7 +199,6 @@ const updateBackgroundFancy = (processedPalette) => {
     console.log("Processed palette", processedPalette);
     if (JSON.stringify(oldFancyColors) !== JSON.stringify(processedPalette)) {
         oldFancyColors = processedPalette;
-        // I shouldn't have done that but it works
         import("./fancyBlur.js")
             .then(({ updateColors }) => {
                 updateColors(processedPalette);
@@ -220,10 +209,80 @@ const updateBackgroundFancy = (processedPalette) => {
     }
 };
 
-// flow: set duration -> start animation -> removeAnimation -> repeat
+// Options Logic
+const initOptions = () => {
+    const optionsBtn = document.querySelector("#options-btn");
+    const optionsMenu = document.querySelector("#options-menu");
+    const spinToggle = document.querySelector("#spin-toggle");
+    const shapeSelect = document.querySelector("#shape-select");
+
+    // Load preferences
+    const isSpinning = localStorage.getItem("coverSpinning") !== "false";
+    const coverShape = localStorage.getItem("coverShape") || "circle";
+
+    spinToggle.checked = isSpinning;
+    shapeSelect.value = coverShape;
+
+    spinToggle.disabled = coverShape !== "circle";
+
+    applySpinning(isSpinning);
+    applyShape(coverShape);
+
+    optionsBtn.onclick = (e) => {
+        e.stopPropagation();
+        optionsMenu.classList.toggle("visible");
+    };
+
+    document.addEventListener("click", (e) => {
+        if (!optionsMenu.contains(e.target) && e.target !== optionsBtn) {
+            optionsMenu.classList.remove("visible");
+        }
+    });
+
+    spinToggle.onchange = (e) => {
+        const spinning = e.target.checked;
+        localStorage.setItem("coverSpinning", spinning);
+        applySpinning(spinning);
+    };
+
+    shapeSelect.onchange = (e) => {
+        const shape = e.target.value;
+        localStorage.setItem("coverShape", shape);
+        spinToggle.disabled = shape !== "circle";
+        applyShape(shape);
+    };
+};
+
+const applySpinning = (isSpinning) => {
+    const container = document.querySelector("#spin-container");
+    const shape = localStorage.getItem("coverShape") || "circle";
+    
+    if (isSpinning && shape === "circle") {
+        container.classList.add("spinning");
+    } else {
+        container.classList.remove("spinning");
+    }
+};
+
+const applyShape = (shape) => {
+    const cover = document.querySelector("#cover");
+    const container = document.querySelector("#thumbnail-container");
+    const spinContainer = document.querySelector("#spin-container");
+    
+    cover.classList.remove("circle", "rounded-square");
+    container.classList.remove("circle", "rounded-square");
+    spinContainer.classList.remove("circle", "rounded-square");
+    
+    cover.classList.add(shape);
+    container.classList.add(shape);
+    spinContainer.classList.add(shape);
+    
+    const isSpinning = localStorage.getItem("coverSpinning") !== "false";
+    applySpinning(isSpinning);
+};
+
 
 const setProgressAnimationDuration = (duration) => {
-    // sets duration in seconds
     r.style.setProperty(`--animationDuration`, `${duration}s`);
 };
 
@@ -233,24 +292,26 @@ const startProgressAnimation = () => {
 
 const removeProgressAnimation = () => {
     document.querySelector(".thumbnail-border").classList.remove("animate");
+    r.style.setProperty(`--animationCurrent`, `0s`);
 };
 
 const pauseProgressAnimationAndCover = () => {
     document.querySelector(".thumbnail-border").classList.add("paused");
-    document.querySelector(".song-thumbnail").classList.add("paused");
+    document.querySelector("#spin-container").classList.add("paused");
 };
 
 const resumeProgressAnimationAndCover = () => {
     document.querySelector(".thumbnail-border").classList.remove("paused");
-    document.querySelector(".song-thumbnail").classList.remove("paused");
+    document.querySelector("#spin-container").classList.remove("paused");
 };
 
 const restartAnimation = (duration) => {
-    removeProgressAnimation();
-    setTimeout(() => {
-        setProgressAnimationDuration(duration);
-        startProgressAnimation();
-    }, 10);
+    const border = document.querySelector(".thumbnail-border");
+    border.classList.remove("animate");
+    r.style.setProperty(`--animationCurrent`, `0s`);
+    r.style.setProperty(`--animationDuration`, `${duration}s`);
+    void border.offsetWidth;
+    border.classList.add("animate");
 };
 
 let socket = io();
@@ -261,8 +322,9 @@ socket.on("metadata", (metadata) => {
     title.textContent = metadata.title;
     album.textContent = metadata.album;
     artist.textContent = metadata.artist;
-    // placeholder duration in case the retrieval fails
-    restartAnimation(180);
+    
+    document.title = `${metadata.title} | ShairportGUI`;
+    
 });
 
 socket.on("pictureData", (pictureData) => {
@@ -289,9 +351,35 @@ socket.on("palette", (palette) => {
     }
 });
 
-socket.on("progress", (progress) => {
-    console.log("Progress", progress);
-    restartAnimation(progress != 1 ? progress : 180); // fallback value
+let currentDuration = 0;
+let lastProgressTime = 0;
+let lastProgressRealTime = 0;
+
+socket.on("progress", (data) => {
+    const border = document.querySelector(".thumbnail-border");
+    if (typeof data === 'object' && data !== null) {
+        if (data.duration > 0) {
+            const expectedCurrent = lastProgressTime + (Date.now() - lastProgressRealTime) / 1000;
+            const isDesynced = Math.abs(data.current - expectedCurrent) > 1.5;
+            const durationChanged = Math.abs(data.duration - currentDuration) > 1;
+            
+            if (!border.classList.contains("animate") || isDesynced || durationChanged) {
+                border.classList.remove("animate");
+                r.style.setProperty(`--animationDuration`, `${data.duration}s`);
+                r.style.setProperty(`--animationCurrent`, `${data.current}s`);
+                
+                void border.offsetWidth;
+                border.classList.add("animate");
+                
+                currentDuration = data.duration;
+                lastProgressTime = data.current;
+                lastProgressRealTime = Date.now();
+            }
+        }
+    } else {
+        let duration = data != 1 ? data : 180;
+        restartAnimation(duration);
+    }
 });
 
 socket.on("playing", (playing) => {

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Khula:wght@400;600;700&family=Public+Sans:wght@100;300;400;600&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
 
 :root {
   --brShadowColorRaw: 151, 0, 116;
@@ -19,53 +19,57 @@
   --pgPercentage: 100;
   --value: 100;
   --animationDuration: 40s;
-  --progressBackground: #fff
+  --progressBackground: #fff;
+  
+  --coverSize: clamp(300px, 40vw, 600px);
 }
 
 /* change flex direction to column on portrait, adjust for needs */
-@media (max-width: 1200px) {
+@media (max-width: 1000px) {
   .container {
     flex-direction: column !important;
+    justify-content: center !important;
+    gap: 5vh;
   }
 
   .song-details {
-    width: auto !important;
+    width: 90% !important;
     text-align: center;
-    padding-left: 1vw;
-    padding-right: 1vw;
+    padding: 0 !important;
+    align-items: center;
   }
 
   .thumbnail-border {
-    width: 70vw !important;
-    height: 70vw !important;
-    padding: 1vh !important;
+    width: clamp(250px, 70vw, 500px) !important;
+    height: clamp(250px, 70vw, 500px) !important;
   }
-
-  .song-thumbnail {
-    height: 70vw !important;
-    width: 70vw !important;
+  
+  .thumbnail-border {
+    width: clamp(250px, 70vw, 500px) !important;
+    height: clamp(250px, 70vw, 500px) !important;
   }
 
   .song-title {
-    font-size: 8vw !important;
+    font-size: clamp(2rem, 8vw, 4rem) !important;
   }
 
   .album-title {
-    font-size: 4vw !important;
+    font-size: clamp(1rem, 4vw, 2rem) !important;
   }
 
   .artist {
-    font-size: 5vw !important;
+    font-size: clamp(1.2rem, 5vw, 2.5rem) !important;
   }
 }
 
-
 body {
   background-color: #fff;
-  font-family: 'Public Sans', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
   color: var(--songColor);
   overflow: hidden;
   margin: 0;
+  height: 100vh;
+  width: 100vw;
 }
 
 .orb-canvas {
@@ -81,12 +85,13 @@ body {
 .container {
   position: absolute;
   z-index: 1000;
-  height: 100vh;
+  height: 100%;
   width: 100%;
   display: flex;
   flex-direction: row;
   align-items: center;
-  justify-content: space-evenly;
+  justify-content: center;
+  gap: 10vw;
 }
 
 .background-img {
@@ -111,8 +116,58 @@ body {
 .song-thumbnail {
   height: 100%;
   width: 100%;
-  border-radius: 50%;
+  object-fit: cover;
+  transition: border-radius 0.3s ease;
+}
+
+.song-thumbnail.spinning {
   animation: spin 40s linear infinite;
+}
+
+.song-thumbnail.spinning.paused {
+  animation-play-state: paused !important;
+}
+
+.thumbnail-border {
+  --pgPercentage: var(--value);
+  background:
+    radial-gradient(closest-side, var(--progressBackground) 80%, transparent 0 99.9%),
+    conic-gradient(var(--borderColor) calc(var(--pgPercentage) * 1%), var(--progressBackground) 0);
+  display: flex;
+  width: var(--coverSize);
+  height: var(--coverSize);
+  padding: 1vw;
+  box-shadow: inset 6px 6px 20px 0 rgba(var(--brShadowColorRaw), 0.2),
+    0px 4px 20px rgba(var(--brShadowColorRaw), 0.1),
+    0px 8px 24px rgba(var(--brShadowColorRaw), 0.1),
+    0px 16px 45px rgba(var(--tlShadowColorRaw), 0.4);
+  cursor: pointer;
+  transition: border-radius 0.3s ease;
+}
+
+.spin-container {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  transition: border-radius 0.3s ease;
+}
+
+.circle {
+  border-radius: 50% !important;
+}
+
+.rounded-square {
+  border-radius: 15% !important;
+}
+
+.spinning {
+  animation: spin 40s linear infinite;
+}
+
+.spinning.paused {
+  animation-play-state: paused !important;
 }
 
 @keyframes growProgressBar {
@@ -125,12 +180,14 @@ body {
   }
 }
 
-/*
-  Note:
-  Supported only by Chromium
-  Fallback is just a regular border
-  Sorry Firefox users :(
-*/
+.animate {
+  animation: growProgressBar var(--animationDuration) 1 linear forwards;
+  animation-delay: calc(var(--animationCurrent, 0s) * -1);
+}
+
+.animate.paused {
+  animation-play-state: paused !important;
+}
 
 @property --pgPercentage {
   syntax: '<number>';
@@ -138,66 +195,132 @@ body {
   initial-value: 0;
 }
 
-.animate {
-  animation: growProgressBar var(--animationDuration) 1 linear;
-}
-
-.paused {
-  animation-play-state: paused;
-}
-
-.thumbnail-border {
-  --pgPercentage: var(--value);
-  background:
-    radial-gradient(closest-side, var(--progressBackground) 80%, transparent 0 99.9%),
-    conic-gradient(var(--borderColor) calc(var(--pgPercentage) * 1%), var(--progressBackground) 0);
-
-  display: flex;
-  width: 40vw;
-  height: 40vw;
-  border-radius: 50%;
-  padding: 1vw;
-  box-shadow: inset 6px 6px 20px 0 rgba(var(--brShadowColorRaw), 0.2),
-    0px 4px 20px rgba(var(--brShadowColorRaw), 0.1),
-    0px 8px 24px rgba(var(--brShadowColorRaw), 0.1),
-    0px 16px 45px rgba(var(--tlShadowColorRaw), 0.4);
-  cursor: pointer;
-}
-
 .song-details {
   display: flex;
   flex-direction: column;
-  text-overflow: ellipsis;
-  overflow: hidden;
-  white-space: normal;
   text-shadow: var(--brShadow), var(--tlShadow);
-  overflow: visible;
-  width: 35%;
-  /* Hardcoded width cause text moves the thumbnail away */
+  width: 40%;
 }
 
 .song-title {
-  font-size: 4.5vw;
+  font-size: clamp(2rem, 4.5vw, 5rem);
   font-weight: bolder;
+  margin-bottom: 0.5rem;
 }
 
 .album-title {
-  font-size: 2.2vw;
+  font-size: clamp(1rem, 2.2vw, 2.5rem);
   color: var(--artistColor);
-  padding-top: 6rem;
   font-weight: 600;
+  margin-bottom: 0.5rem;
 }
 
 .artist {
-  font-size: 2.8vw;
+  font-size: clamp(1.2rem, 2.8vw, 3rem);
   color: var(--artistColor);
-  padding-top: 1.5rem;
   font-weight: 600;
+  margin-bottom: 2rem;
+}
+
+.playback-controls {
+  display: flex;
+  gap: 2rem;
+  margin-top: 1rem;
+}
+
+.playback-controls button {
+  background: rgba(255, 255, 255, 0.2);
+  border: 1px solid rgba(var(--borderColorRaw), 0.5);
+  color: var(--songColor);
+  font-size: 1.5rem;
+  padding: 1rem;
+  border-radius: 50%;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  backdrop-filter: blur(5px);
+  width: 60px;
+  height: 60px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.playback-controls button:hover {
+  background: rgba(var(--borderColorRaw), 0.3);
+  transform: scale(1.1);
+}
+
+.options-btn {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  z-index: 2000;
+  background: rgba(255, 255, 255, 0.2);
+  border: 1px solid rgba(var(--borderColorRaw), 0.5);
+  color: var(--songColor);
+  font-size: 1.5rem;
+  padding: 1rem;
+  border-radius: 50%;
+  cursor: pointer;
+  backdrop-filter: blur(5px);
+  width: 50px;
+  height: 50px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: transform 0.3s ease;
+}
+
+.options-btn:hover {
+  transform: rotate(90deg);
+}
+
+.options-menu {
+  position: fixed;
+  bottom: 80px;
+  right: 20px;
+  z-index: 2000;
+  background: rgba(255, 255, 255, 0.8);
+  backdrop-filter: blur(10px);
+  border: 1px solid rgba(var(--borderColorRaw), 0.5);
+  padding: 1.5rem;
+  border-radius: 1rem;
+  display: none;
+  min-width: 200px;
+  box-shadow: 0 10px 25px rgba(0,0,0,0.1);
+}
+
+.options-menu.visible {
+  display: block;
+  animation: slideUp 0.3s ease;
+}
+
+@keyframes slideUp {
+  from { opacity: 0; transform: translateY(20px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.options-menu h3 {
+  margin-top: 0;
+  margin-bottom: 1rem;
+  font-size: 1.2rem;
+}
+
+.option-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+  gap: 1rem;
+}
+
+.option-item label {
+  font-size: 0.9rem;
+  color: #333;
 }
 
 @keyframes spin {
   100% {
-    -webkit-transform: rotate(360deg);
     transform: rotate(360deg);
   }
 }

--- a/src/ShairportProvider.js
+++ b/src/ShairportProvider.js
@@ -1,6 +1,6 @@
 import SongProvider from "./SongProvider";
 import ShairportReader from "shairport-sync-reader";
-import { emitSongCover, emitSongMeta, emitSongProgress } from "./utils";
+import { emitSongCover, emitSongMeta, emitSongProgress, emitSongPlaying } from "./utils";
 
 export default class ShairportProvider extends SongProvider {
     constructor(io, path) {
@@ -23,8 +23,31 @@ export default class ShairportProvider extends SongProvider {
             emitSongCover(io, pictureData);
         });
         this.pipeReader.on("prgr", function (progress) {
-            console.log("Progress: " + progress);
-            emitSongProgress(io, progress);
+            console.log("Progress: ", progress);
+            if (progress && progress.start && progress.end && progress.current) {
+                let start = progress.start;
+                let end = progress.end;
+                let current = progress.current;
+                
+                if (end < start) end += 4294967296;
+                if (current < start) current += 4294967296;
+
+                const duration = (end - start) / 44100;
+                const currentTime = (current - start) / 44100;
+                emitSongProgress(io, { duration, current: currentTime });
+            } else {
+                emitSongProgress(io, progress);
+            }
+        });
+
+        this.pipeReader.on("pbeg", function () {
+            console.log("Playback started");
+            emitSongPlaying(io, true);
+        });
+
+        this.pipeReader.on("pend", function () {
+            console.log("Playback ended");
+            emitSongPlaying(io, false);
         });
     }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ const app = express();
 const server = http.createServer(app);
 const io = new Server(server, {
     cors: {
-        origin: "192.168.1.181:3000", // change this to your local ip
+        origin: "192.168.5.11:3000", // change this to your local ip (run alongside shairport-sync/spotify server)
         methods: ["GET,POST"],
         credentials: true
     },

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,5 @@
 import fs from "fs";
-import vibrant from "node-vibrant";
+import { Vibrant } from "node-vibrant/node";
 
 let previousPalette = {};
 
@@ -26,13 +26,14 @@ const checkIfImageIsBrightOrDark = (image) => {
 
 const emitPalette = (io, image) => {
     checkIfImageIsBrightOrDark(image);
-    vibrant.from(image).getPalette((err, palette) => {
-        // palette should be same for same images on a single machine, should...
-        if (previousPalette !== palette) {
-            previousPalette = palette;
-            io.emit("palette", palette);
-        }
-    });
+    Vibrant.from(image).getPalette()
+        .then((palette) => {
+            if (previousPalette !== palette) {
+                previousPalette = palette;
+                io.emit("palette", palette);
+            }
+        })
+        .catch((err) => console.error("Palette extraction error:", err));
 };
 
 export function emitSongMeta(io, title, artist, album) {


### PR DESCRIPTION
## Features: Visual & timing fixes
### Fixes a handful of long-standing bugs around animation timing and cover art layout.

### Progress bar desync
- The old `setTimeout`-based reset was brittle by design. Replaced it with a synchronous layout reflow (`void border.offsetWidth`) - resets are now instant. Also added drift correction: if CSS animation falls more than 1.5s out of sync with the server's reported playback time, it corrects itself automatically. Fixed `start`, `end`, and `current` timestamps in the `prgr` packet while I was in there - `current` wasn't reporting correctly.

### Options menu 
- Implemented options menu for changing setting for Cover Spinning and Cover's shape.
![Options](https://i.imgur.com/dGbINSp.png)

### Font stack (or Typography)
- Switched to `-apple-system, BlinkMacSystemFont` - San Francisco renders natively on Apple platforms now. Falls back to Inter (Google Fonts) on Linux (not considering Windows a system). Cleaner, sharper, more pleasing for my ADHD eyes.

### CSS cleanup
- Dropped overly-specific selectors like `.animate.spinning` and `.thumbnail-border.circle` in favor of global layout classes - `.circle`, `.rounded-square`. They cascade cleanly down the DOM and are much easier to work with going forward.

![ShairportGUI](https://i.imgur.com/blSlrDl.png)
## Known issues & limitations
### Cover art spin delay on pause 
- Cover doesn't stop spinning immediately when playback pauses. This is a shairport-sync timing issue, not something I can fix on my end cleanly.
### No playback controls (AirPlay) 
- Pause/Play/Forward/Backward controls aren't implemented for AirPlay (and Spotify yet). The protocol bits that handle this are closed-source, and the shairport-sync repo explicitly notes this limitation. Spotify is a different story - controls are probably doable there since the API is open.

## Also - my roadmap for this project (I find it really cool):
### UI Overhaul - Apple Music / Spotify aesthetic
- Full visual redesign taking cues from Apple Music and Spotify's UI language - clean typography, blurred backgrounds, smooth transitions. The current layout works but doesn't feel premium. This would bring it up to that level.

### HomeKit RGB integration
- Implementing ambient lighting sync via HomeKit - LED strip reacts to playback state or cover art colors. Easiest path is through Homebridge. Blocked on hardware for now - need to acquire a controllable LED strip first (I was thinking about it).

### Replace Spotify token flow with data from FOSS Spotify Server - spocon
- Current Spotify token handling is a workaround. `spocon` runs a local server that handles auth transparently, no token juggling. Straightforward swap once I sit down with it.

### Additional providers
- Tidal - on the list, haven't dug into the API yet
- Pandora - no idea where to even start with this one, skipping for now